### PR TITLE
feat: add direct DB-backed reads for lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ The current upstream enum only exposes `AWS_SES`, so the CLI defaults `--driver`
 ### Postgres Proxy
 
 Manage the workspace Postgres proxy credential lifecycle.
+This is optional bootstrap support for deployments that expose it, not the
+primary DB-first configuration path.
 
 ```bash
 twenty postgres-proxy <operation> [options]
@@ -239,6 +241,25 @@ twenty postgres-proxy disable
 ```
 
 Upstream returns plaintext credentials for all three operations, so the CLI masks `password` by default unless `--show-password` is set explicitly.
+
+### DB-First Reads
+
+For self-hosted deployments, the CLI can automatically prefer direct database
+reads for supported lookup paths when you provide `TWENTY_DATABASE_URL` in
+`.env`, `.env.local`, your explicit `--env-file`, or the process environment.
+You can also save the same URL into a workspace-scoped DB profile and make that
+profile active with `twenty db profile use <name>`.
+
+Today the DB-first path is intended for fast, read-only lookups:
+
+- `twenty search`
+- `twenty api list <object>`
+- `twenty api get <object> <id>`
+- `twenty api group-by <object>`
+
+Mutations stay on the official Twenty API even when DB-first reads are active.
+If no DB configuration is present, or if a supported DB read cannot run safely,
+the CLI falls back to the API path.
 
 ### Roles
 

--- a/docs/superpowers/specs/2026-04-10-raycast-twenty-extension-design.md
+++ b/docs/superpowers/specs/2026-04-10-raycast-twenty-extension-design.md
@@ -11,7 +11,7 @@ Rework the upstream Raycast `extensions/twenty` extension through a sequence of 
 The target outcome is:
 
 - keep `extensions/twenty` as the upstream extension instead of creating a forked store entry
-- add correct self-hosted Twenty support through a base URL preference
+- improve the existing base URL preference so onboarding clearly supports hosted and self-hosted Twenty instances
 - internally replace the current narrow `TwentySDK` implementation with a typed client/service layer
 - preserve and improve generic native Twenty object-record creation
 - add a Google-Contacts-style people workflow backed by the native Twenty `people` object
@@ -36,7 +36,7 @@ Current state:
 
 - active upstream extension with recent maintenance
 - only supports a single `Create Object Record` command
-- already exposes a token preference and a URL preference
+- already exposes a token preference and a URL preference, but the hosted versus self-hosted onboarding is not clear enough
 - current implementation is built around a narrow `TwentySDK` wrapper and object-create form flow
 
 Problems in the current implementation:
@@ -69,6 +69,16 @@ The local `twenty-cli` repo contains cleaner primitives than the current Raycast
 - search service for Twenty GraphQL search
 
 These patterns should be ported into the Raycast extension, but the Raycast extension should not directly depend on the external `@salmonumbrella/twenty-cli` package at runtime.
+
+## Implementation Setup
+
+Before implementation begins, clone `raycast/extensions` locally and work in that checkout as the PR source.
+
+Optional helper workflow:
+
+- generate a local digest or gitingest-style summary for fast agent orientation
+
+But the source of truth should remain the local upstream clone itself, not a generated digest file.
 
 ## Goals
 
@@ -115,6 +125,7 @@ PR 1 should introduce a typed internal service layer with responsibilities rough
 
 - config and preference resolution
 - URL normalization
+- onboarding-friendly preference defaults and validation
 - HTTP client and error translation
 - metadata service for objects and fields
 - records service for list/get/create/update/delete
@@ -129,6 +140,8 @@ The client layer should normalize:
 - input values that may already include `/rest`
 
 The client layer should not silently fall back to production hosted Twenty when the user supplied an invalid self-hosted URL. Invalid user input should surface as configuration error.
+
+The onboarding flow should make it obvious that users can point the extension at a custom Twenty URL. The hosted default should be treated as a first-class configurable value rather than an invisible fallback.
 
 ### Generic Object Handling
 
@@ -166,6 +179,8 @@ Expected behaviors:
 - create a new person from a full form
 - quick-add a person from arguments or a compact form
 - action shortcuts for relevant contact operations when the fields exist
+- direct copy actions for primary email and phone, with keyboard shortcuts where Raycast supports them
+- linked-note lookup when a person has related Twenty notes that can be fetched cleanly via API
 
 Field mapping should remain Twenty-native. Examples of likely mappings:
 
@@ -179,21 +194,25 @@ Field mapping should remain Twenty-native. Examples of likely mappings:
 
 Not every Google Contacts feature should be mirrored. If a feature does not map cleanly to native Twenty `people`, it should be omitted or adapted instead of faked.
 
+The `people` workflow must be metadata-driven enough to support custom fields on the native `people` object. Standard fields should get polished handling, but custom fields on `people` should still be displayed and editable through the same API-backed form and detail flow.
+
 ## Delivery Plan
 
 ### PR 1: Foundation Rewrite And Self-Hosted Support
 
 Scope:
 
-- add and validate explicit base URL preference handling
+- validate and improve explicit base URL preference handling
 - rewrite the current `TwentySDK` into a typed internal client/service layer
 - clean up error handling and configuration failures
 - rebuild generic object-create flow on top of the new services
 - finish generic native field support for phone number, currency, boolean, rating, and multi-select
+- make hosted versus self-hosted onboarding clearer for first-time setup
 
 Exit criteria:
 
 - hosted and self-hosted instances both work
+- onboarding clearly presents the hosted default URL and the ability to override it with a custom instance URL
 - no object-name hacks for primary-field assumptions remain in the core create flow unless forced by missing metadata
 - generic create flow remains functional
 
@@ -206,11 +225,15 @@ Scope:
 - add create/edit person flow
 - add quick-add person command
 - add person actions that map cleanly to native Twenty data
+- support copy-email and copy-phone actions with shortcuts where possible
+- fetch and surface linked Twenty notes when the person schema or relations make that available
+- ensure custom fields on the native `people` object are visible and editable through metadata-driven rendering
 
 Exit criteria:
 
 - extension can be used as a contact browser/editor for a normal Twenty `people` dataset
 - self-hosted instances work the same as hosted ones
+- custom fields on `people` do not disappear just because the UI was designed around standard fields
 
 ### PR 3: Extension Expansion
 

--- a/docs/superpowers/specs/2026-04-10-raycast-twenty-extension-design.md
+++ b/docs/superpowers/specs/2026-04-10-raycast-twenty-extension-design.md
@@ -1,0 +1,267 @@
+# Raycast Twenty Extension Rewrite Design
+
+Date: 2026-04-10
+Status: Approved in chat, written for review
+Owner: Codex session in `twenty-cli`
+
+## Summary
+
+Rework the upstream Raycast `extensions/twenty` extension through a sequence of small pull requests.
+
+The target outcome is:
+
+- keep `extensions/twenty` as the upstream extension instead of creating a forked store entry
+- add correct self-hosted Twenty support through a base URL preference
+- internally replace the current narrow `TwentySDK` implementation with a typed client/service layer
+- preserve and improve generic native Twenty object-record creation
+- add a Google-Contacts-style people workflow backed by the native Twenty `people` object
+
+This project copies the successful UX patterns from `extensions/google-contacts`, but the source of truth remains the standard Twenty schema, especially the native `people` object.
+
+## Decision
+
+Implement this as a sequence of focused upstream PRs against `raycast/extensions`, not as:
+
+- a standalone forked extension
+- a one-shot large PR
+- a thin patch on top of the current `extensions/twenty` internals
+
+The current `extensions/twenty` should be treated as an upstream target with partially reusable UI surface, but not as an architecture to preserve.
+
+## Context And Research
+
+### Upstream `extensions/twenty`
+
+Current state:
+
+- active upstream extension with recent maintenance
+- only supports a single `Create Object Record` command
+- already exposes a token preference and a URL preference
+- current implementation is built around a narrow `TwentySDK` wrapper and object-create form flow
+
+Problems in the current implementation:
+
+- service layer returns weak result types like `string | boolean`
+- base URL handling is simplistic and not robust for hosted versus self-hosted normalization
+- record creation flow hard-codes assumptions about primary fields such as `name` and `title`
+- the extension architecture is not set up for browse/search/detail/edit workflows
+
+### Upstream `extensions/google-contacts`
+
+`google-contacts` provides the UX reference to port:
+
+- dedicated search/browse command
+- list/detail and grid browsing modes
+- componentized actions and forms
+- create/edit flows built around a consistent client and hook layer
+- quick-add command
+
+This extension is structurally closer to the desired Raycast behavior than the current `extensions/twenty`.
+
+### Local `twenty-cli`
+
+The local `twenty-cli` repo contains cleaner primitives than the current Raycast Twenty extension:
+
+- workspace and base URL resolution
+- reusable HTTP client with retries and debug support
+- metadata services for objects and fields
+- generic records CRUD services
+- search service for Twenty GraphQL search
+
+These patterns should be ported into the Raycast extension, but the Raycast extension should not directly depend on the external `@salmonumbrella/twenty-cli` package at runtime.
+
+## Goals
+
+- Upstream work into `raycast/extensions` through small PRs
+- Support self-hosted Twenty instances via explicit base URL preference
+- Make the extension work cleanly against the native Twenty `people` object
+- Port the successful contact-management UX patterns from `google-contacts`
+- Improve the generic native-object story of the existing Twenty extension where it is part of the promised scope
+
+## Non-Goals
+
+- creating a new standalone Raycast extension with a separate store identity
+- inventing a parallel local sync layer outside Twenty
+- forcing a Google People data model onto Twenty where the native schema differs
+- blocking the people workflow on every possible generic-object enhancement
+
+## Product Scope
+
+The native Twenty `people` object is the contact source of truth.
+
+The extension should present people/contact workflows that feel similar to `google-contacts`, but field mapping must stay faithful to Twenty. The extension should only expose behaviors that map cleanly to standard Twenty data.
+
+## Architecture
+
+### Extension Boundary
+
+The Raycast extension should contain its own extension-native client layer.
+
+It should:
+
+- reuse design patterns from `twenty-cli`
+- copy or adapt the relevant client/service logic into `extensions/twenty`
+- avoid a runtime dependency on a package published from another repository
+
+Reasons:
+
+- upstream maintainers will expect the extension to be self-contained in the Raycast repo
+- release/versioning would be awkward if the extension depended on an external package
+- the Raycast extension needs a smaller, UI-oriented surface than the full CLI package
+
+### Client Layer
+
+PR 1 should introduce a typed internal service layer with responsibilities roughly split as:
+
+- config and preference resolution
+- URL normalization
+- HTTP client and error translation
+- metadata service for objects and fields
+- records service for list/get/create/update/delete
+- people-oriented service helpers where needed
+- search service where useful for browse/find experiences
+
+The client layer should normalize:
+
+- hosted Twenty URLs
+- self-hosted URLs
+- input values with or without trailing slash
+- input values that may already include `/rest`
+
+The client layer should not silently fall back to production hosted Twenty when the user supplied an invalid self-hosted URL. Invalid user input should surface as configuration error.
+
+### Generic Object Handling
+
+The rewritten generic object-create flow should be metadata-driven instead of object-name-driven.
+
+Where the existing extension has TODOs for native field support, PR 1 should implement the native field types that are straightforward to support in the generic object-create flow:
+
+- phone number
+- currency
+- boolean
+- rating
+- multi-select
+
+Relation support should be treated as a separate complexity tier and explicitly deferred to PR 3 unless the rewritten metadata and form layer make it trivial during implementation.
+
+The implementation should prioritize field support that is native to Twenty and useful for both generic object creation and the `people` object.
+
+### Contact UX Mapping
+
+PR 2 should add a people workflow inspired by `google-contacts`.
+
+Expected commands:
+
+- `Search People`
+- `Create Person`
+- `Quick Add Person`
+
+The main `Search People` command should support a browse/search/detail workflow that feels close to `google-contacts`, adapted to Twenty’s schema.
+
+Expected behaviors:
+
+- search and browse people records
+- open detail view for a selected person
+- edit person from the result list
+- create a new person from a full form
+- quick-add a person from arguments or a compact form
+- action shortcuts for relevant contact operations when the fields exist
+
+Field mapping should remain Twenty-native. Examples of likely mappings:
+
+- display name: native person name fields
+- email addresses: Twenty email fields if present
+- phone numbers: Twenty phone fields if present
+- company or title: native company/title-related fields if present
+- links and socials: Twenty links fields
+- notes: text field if present
+- avatar: image/avatar field if available
+
+Not every Google Contacts feature should be mirrored. If a feature does not map cleanly to native Twenty `people`, it should be omitted or adapted instead of faked.
+
+## Delivery Plan
+
+### PR 1: Foundation Rewrite And Self-Hosted Support
+
+Scope:
+
+- add and validate explicit base URL preference handling
+- rewrite the current `TwentySDK` into a typed internal client/service layer
+- clean up error handling and configuration failures
+- rebuild generic object-create flow on top of the new services
+- finish generic native field support for phone number, currency, boolean, rating, and multi-select
+
+Exit criteria:
+
+- hosted and self-hosted instances both work
+- no object-name hacks for primary-field assumptions remain in the core create flow unless forced by missing metadata
+- generic create flow remains functional
+
+### PR 2: People Contact Workflow
+
+Scope:
+
+- port the interaction model from `google-contacts` into `extensions/twenty`
+- add browse/search/detail views for `people`
+- add create/edit person flow
+- add quick-add person command
+- add person actions that map cleanly to native Twenty data
+
+Exit criteria:
+
+- extension can be used as a contact browser/editor for a normal Twenty `people` dataset
+- self-hosted instances work the same as hosted ones
+
+### PR 3: Extension Expansion
+
+Scope:
+
+- add relation-field support for generic native objects if it did not land earlier
+- finish remaining native generic-object support not required for PR 1
+- consider broader record viewing across objects if it still fits the extension after the people workflow lands
+- close out remaining native-field or object UX gaps
+
+Exit criteria:
+
+- old upstream TODOs that still matter are either implemented or intentionally removed from the roadmap
+
+## Testing Strategy
+
+Each PR should include targeted verification appropriate to its scope.
+
+### PR 1
+
+- preference parsing and URL normalization
+- hosted URL and self-hosted URL request construction
+- service-level tests for metadata and record flows
+- manual smoke test for create-object flow
+
+### PR 2
+
+- people search and browse behavior
+- person create and edit flows
+- quick-add flow
+- self-hosted smoke test against a real local Twenty instance
+
+### PR 3
+
+- native field rendering and submission tests for newly supported field types
+- generic-object viewing or listing tests if added
+
+## Risks
+
+- Twenty metadata may still not expose enough information to infer every ideal form behavior cleanly
+- relation-field UX in Raycast may require more design work than other field types
+- the native `people` schema may not match every `google-contacts` affordance one-to-one
+- upstream maintainers may prefer narrower PRs than expected, so each PR should stay independently useful
+
+## Open Decisions Already Resolved
+
+- Upstream target: `extensions/twenty`
+- Contact source of truth: native standard Twenty `people` object
+- Delivery style: sequence of smaller PRs
+- Architecture: internal rewrite using `twenty-cli` patterns, not direct package dependency
+
+## Next Step
+
+After review of this design doc, create an implementation plan for PR 1 only.

--- a/docs/superpowers/specs/2026-04-17-twenty-dbfirst-read-platform-design.md
+++ b/docs/superpowers/specs/2026-04-17-twenty-dbfirst-read-platform-design.md
@@ -4,6 +4,18 @@ Date: 2026-04-17
 Status: Proposed
 Scope: Implicit DB-first read architecture for `twenty-cli`
 
+## Reference Codebases
+
+Local reference repos used during this design:
+
+- `beeper-cli`: `/Users/sadimir/code/experiments/beeper-cli`
+- `chatwoot-cli`: `/Users/sadimir/repositories/github.com/wanver/chatwoot-cli`
+
+These paths matter because this design intentionally borrows:
+
+- operator diagnostics ideas from `beeper-cli`
+- the backend-owned DB-first read architecture from `chatwoot-cli`
+
 ## Summary
 
 `twenty-cli` should adopt a DB-first read architecture for self-hosted and

--- a/docs/superpowers/specs/2026-04-17-twenty-dbfirst-read-platform-design.md
+++ b/docs/superpowers/specs/2026-04-17-twenty-dbfirst-read-platform-design.md
@@ -8,8 +8,8 @@ Scope: Implicit DB-first read architecture for `twenty-cli`
 
 Local reference repos used during this design:
 
-- `beeper-cli`: `/Users/sadimir/code/experiments/beeper-cli`
-- `chatwoot-cli`: `/Users/sadimir/repositories/github.com/wanver/chatwoot-cli`
+- `beeper-cli`: `~/code/experiments/beeper-cli`
+- `chatwoot-cli`: `~/repositories/github.com/wanver/chatwoot-cli`
 
 These paths matter because this design intentionally borrows:
 

--- a/docs/superpowers/specs/2026-04-17-twenty-dbfirst-read-platform-design.md
+++ b/docs/superpowers/specs/2026-04-17-twenty-dbfirst-read-platform-design.md
@@ -1,0 +1,539 @@
+# Twenty DB-First Read Platform Design
+
+Date: 2026-04-17
+Status: Proposed
+Scope: Implicit DB-first read architecture for `twenty-cli`
+
+## Summary
+
+`twenty-cli` should adopt a DB-first read architecture for self-hosted and
+proxy-enabled Twenty workspaces, using the current `postgres-proxy`
+capability as the preferred bootstrap path and keeping all write actions on
+the official API.
+
+The design should follow the successful shape of `chatwoot-cli`, not
+`beeper-cli`.
+
+What to copy from `chatwoot-cli`:
+
+- one backend abstraction owned by the runtime rather than command flags
+- DB-first reads when a usable database configuration exists
+- narrow fallback rules based on capability gaps
+- adapters that preserve existing output contracts
+- mutations staying API-only
+
+What not to copy from `chatwoot-cli`:
+
+- public `api | db | auto` mode switches on user-facing read commands
+
+What to copy from `beeper-cli`:
+
+- strong diagnostics for operators
+
+What not to copy from `beeper-cli`:
+
+- local filesystem database discovery
+
+This differs from Chatwoot in one important way: Twenty already exposes a
+first-class `postgres-proxy` workflow that can return workspace-scoped
+database credentials. Chatwoot does not expose an equivalent product feature,
+which is why `chatwoot-cli` had to rely on an operator-provided
+`CHATWOOT_DATABASE_URL`. Twenty should take advantage of the product feature it
+already has.
+
+## Goals
+
+- Make read-only record retrieval DB-first whenever a usable DB profile or
+  explicit DB target is configured.
+- Keep backend choice implicit on normal commands.
+- Prefer `postgres-proxy get` as the standard credential bootstrap path.
+- Support an opt-in cached DB profile store with multiple named profiles per
+  workspace such as `prod`, `staging`, and `local`.
+- Keep `.env` support first-class so the feature works equally well for plain
+  env users and 1Password-backed env injection.
+- Preserve current output contracts for `text`, `json`, `jsonl`, `agent`, and
+  `csv`.
+- Cover relationship-heavy reads, not only flat record lookups.
+- Keep all mutations and control-plane actions on the official Twenty API.
+
+## Non-Goals
+
+- Adding public `--read-source`, `--backend`, `db`, `api`, or `auto` switches
+  to normal read commands.
+- Replacing `postgres-proxy` with a second credential system.
+- Rewriting the raw GraphQL or raw REST commands to bypass the public API.
+- Moving mutation flows to direct SQL.
+- Promising DB parity for every control-plane, metadata, workflow, or admin
+  command in the CLI.
+- Requiring users to run Tailscale or manually provision raw database access
+  just to benefit from DB-first reads.
+
+## Selected Architecture
+
+### Runtime policy
+
+Normal read commands should not expose backend selection.
+
+The runtime should decide the backend automatically:
+
+- if a usable DB target exists for the active workspace, use DB-first reads
+- otherwise use the current API path
+- if a DB-backed surface is not yet supported safely, fall back to the API
+  through the shared read backend
+- all mutation commands remain API-only even when DB-first reads are active
+
+This keeps the command UX clean and matches the desired `chatwoot-cli` style:
+the backend is an implementation detail, not a user-facing mode.
+
+### Narrow internal override
+
+There should still be one internal support/debug escape hatch, but it should
+not be part of the normal CLI UX or help contract.
+
+Recommended internal override:
+
+- `TWENTY_INTERNAL_READ_BACKEND=api`
+- `TWENTY_INTERNAL_READ_BACKEND=db`
+
+Rules:
+
+- undocumented in normal README/help output
+- used only for support, troubleshooting, and test coverage
+- never required for normal operation
+
+### Bootstrap model
+
+The standard bootstrap path should be:
+
+1. user configures an endpoint target
+2. CLI fetches or refreshes workspace-scoped credentials through
+   `twenty postgres-proxy get`
+3. CLI caches that configuration only if the user explicitly opted into a DB
+   profile
+4. supported read commands then use DB-first automatically
+
+Important upstream constraint:
+
+- current Twenty returns `user`, `password`, and `workspaceId` from
+  `getPostgresCredentials`
+- current Twenty does not return proxy `host`, `port`, `database`, or
+  `sslmode`
+
+Because of that, the CLI still needs one explicit endpoint target input in
+addition to proxy-fetched credentials.
+
+### Primary endpoint input
+
+Use one explicit env-backed target variable as the primary input:
+
+- `TWENTY_DB_PROXY_URL`
+
+Recommended shape:
+
+- `postgresql://HOST:PORT/DATABASE?sslmode=require`
+
+This is better than split host/port variables as the primary design because it:
+
+- matches Postgres tooling conventions
+- keeps `.env` usage simple
+- is easier to cache and reason about
+- reduces partially configured states
+
+Split endpoint variables can be added later as compatibility helpers if a real
+need appears, but they should not be the primary model.
+
+### DB profile model
+
+DB profiles should be explicit, durable, and multi-profile per workspace.
+
+Recommended public command family:
+
+- `twenty db profile init <name>`
+- `twenty db profile list`
+- `twenty db profile show [name]`
+- `twenty db profile use <name>`
+- `twenty db profile test [name]`
+- `twenty db profile refresh-creds [name]`
+- `twenty db profile remove <name>`
+- `twenty db status`
+
+Profiles are scoped under the active Twenty workspace and support multiple
+named entries such as:
+
+- `prod`
+- `staging`
+- `local`
+
+Recommended profile fields:
+
+- `name`
+- `workspace`
+- `workspaceId`
+- `proxyUrl`
+- `credentialSource`
+- `cachedUser`
+- `cachedPassword`
+- `lastRefreshedAt`
+- `lastValidatedAt`
+- `notes` (optional operator annotation)
+
+Profile storage should be opt-in. Normal reads must not silently create durable
+local config as a side effect.
+
+### Cached credentials
+
+The cached profile store should persist credentials when the user explicitly
+opts into DB profiles.
+
+Rationale:
+
+- faster startup because the CLI can skip a proxy credential fetch in the
+  common case
+- better fit for frequent lookup-heavy usage
+- closer to how famous CLIs handle explicit durable setup
+
+This cache only improves startup and dependency on the API at process start. It
+does not make actual DB queries faster after connection establishment.
+
+### Env compatibility
+
+`.env` support remains first-class.
+
+Reasons:
+
+- it matches the current CLI environment model
+- it works naturally with 1Password-managed env injection
+- it works for users who do not use a secret manager
+- it keeps automation and CI straightforward
+
+Recommended precedence:
+
+1. internal debug override
+2. explicit env target such as `TWENTY_DB_PROXY_URL`
+3. explicit env workspace DB profile selection such as `TWENTY_DB_PROFILE`
+4. cached DB profile selected for the active workspace
+5. API-only fallback
+
+Credentials should resolve in this order:
+
+1. explicit manual env credential override if supported in a later phase
+2. cached profile credentials
+3. live `postgres-proxy get` refresh when API auth is available
+
+### Defaulting
+
+Defaulting should be simple:
+
+- if the active workspace has a usable DB profile or an explicit DB proxy URL,
+  supported read commands default to DB-first
+- if not, they default to the API
+
+No user-facing read command should need to say "use the DB" or "use the API".
+
+### Diagnostics
+
+Diagnostics matter, but they belong in status surfaces rather than mode flags.
+
+Recommended additions:
+
+- extend `twenty auth status` with DB-first visibility
+- add `twenty db status`
+
+Suggested status fields:
+
+- whether a DB target is configured
+- active DB profile name
+- whether cached credentials exist
+- whether credentials were refreshed from `postgres-proxy`
+- whether the DB is reachable
+- which read surfaces are currently DB-capable
+- whether supported reads will currently use DB-first or API-first
+
+### Package shape
+
+The TypeScript package layout should mirror the `chatwoot-cli` separation of
+concerns, adapted to the current repo:
+
+- `packages/twenty-sdk/src/cli/utilities/db`
+  - profile/config loading
+  - connection assembly
+  - capability detection
+  - row adapters
+  - SQL-backed read services
+- `packages/twenty-sdk/src/cli/utilities/readbackend`
+  - backend selection
+  - DB-first fallback harness
+  - per-surface orchestration
+- existing command files
+  - unchanged public UX where possible
+  - continue owning flag parsing and output rendering
+
+The important boundary is:
+
+- commands stay stable
+- services decide whether a read comes from DB or API
+- adapters preserve existing response shapes
+
+### Data model strategy
+
+The design should treat DB-first reads as a generic record-read platform, not a
+hard-coded set of only `people`, `companies`, and `opportunities`.
+
+Scope should include:
+
+- standard objects
+- custom objects
+- relationship-heavy reads exposed through current REST depth/include behavior
+
+That means the runtime needs object metadata awareness so it can resolve:
+
+- object names
+- relation paths
+- field projections
+- table/query capability
+
+Metadata reads themselves do not need to become DB-first in phase 1, but
+metadata-aware planning for record reads is required.
+
+### Fallback policy
+
+Fallback should be narrow and explicit inside the runtime.
+
+Fallback to the API is allowed when:
+
+- no usable DB target exists
+- DB connection cannot be opened
+- cached credentials are invalid and live proxy refresh is unavailable
+- required tables, columns, or relation mappings are unsupported
+- the command shape requests a read surface not yet implemented safely in SQL
+
+Fallback to the API is not allowed for:
+
+- mutation commands
+- raw commands that explicitly promise API semantics
+
+Once a read surface reaches parity, an empty DB result should be treated as
+authoritative rather than causing fallback.
+
+### Output invariants
+
+DB-backed commands must preserve the same output contracts the CLI already
+advertises today.
+
+Invariants:
+
+- command names and normal flags remain stable
+- output shape remains stable
+- query filtering still runs before formatting
+- renderers do not fork by backend
+- JSON payload shape does not expose internal backend details
+
+## Exhaustive Command Surface Inventory
+
+This section lists the current command families in the repo and explicitly
+marks whether they belong in the DB-first read platform.
+
+### Included command families
+
+| Command family | Status | Scope |
+| --- | --- | --- |
+| `twenty search` | In scope | DB-first full-text and relationship-aware record search |
+| `twenty api` | Partially in scope | Read-only record operations become DB-first where safe |
+| `twenty postgres-proxy` | Supporting capability | Credential bootstrap and refresh path, not the read path itself |
+| `twenty db` | New command family | Explicit DB profile and diagnostics management |
+
+### Excluded command families
+
+| Command family | Status | Reason |
+| --- | --- | --- |
+| `twenty auth` | API/control plane | Authentication and workspace config stay API/config-backed; only status gains DB diagnostics |
+| `twenty api-metadata` | Out of scope | Metadata/control-plane surface, not phase-1 DB-first target |
+| `twenty application-registrations` | Out of scope | Control plane |
+| `twenty applications` | Out of scope | Control plane |
+| `twenty approved-access-domains` | Out of scope | Control plane |
+| `twenty calendar-channels` | Out of scope | Integration/config surface |
+| `twenty connected-accounts` | Out of scope | Integration/config surface |
+| `twenty dashboards` | Out of scope | UI/control-plane surface |
+| `twenty emailing-domains` | Out of scope | Control plane |
+| `twenty event-logs` | Out of scope | Operational/analytics surface |
+| `twenty files` | Out of scope | File/storage workflow, not record-read platform |
+| `twenty marketplace-apps` | Out of scope | Control plane |
+| `twenty mcp` | Out of scope | MCP discovery/execution contract should remain API-backed |
+| `twenty message-channels` | Out of scope | Integration/config surface |
+| `twenty openapi` | Out of scope | Documentation/schema retrieval |
+| `twenty public-domains` | Out of scope | Control plane |
+| `twenty raw` | Out of scope | Raw commands must keep explicit API semantics |
+| `twenty roles` | Out of scope | Control plane |
+| `twenty route-triggers` | Out of scope | Control plane |
+| `twenty routes` | Out of scope | HTTP route invocation should stay API/HTTP-backed |
+| `twenty serverless` | Out of scope | Control plane and execution surface |
+| `twenty skills` | Out of scope | Control plane |
+| `twenty webhooks` | Out of scope | Control plane |
+| `twenty workflows` | Out of scope | Control plane and execution surface |
+
+## Detailed `twenty api` Inventory
+
+`twenty api` is mixed-scope. Only read-only record operations should become
+DB-first in this design.
+
+### `twenty api` operations in scope
+
+| Operation | Status | Notes |
+| --- | --- | --- |
+| `list` | In scope | Core DB-first surface for all supported record objects |
+| `get` | In scope | Core DB-first surface, including relationship-heavy expansion |
+| `export` | In scope | Should reuse DB-first list/query pipeline for large read volume |
+| `group-by` | In scope | DB-backed aggregation where semantics can be matched safely |
+
+### `twenty api` operations partially in scope
+
+| Operation | Status | Notes |
+| --- | --- | --- |
+| `list --all` | In scope via `list` | DB paging replaces API pagination fan-out |
+| `get --include <rels>` | In scope via `get` | Relationship-heavy expansion is a primary DB-first target |
+| `export --format json/csv` | In scope via `export` | Rendering stays unchanged; retrieval becomes DB-first |
+
+### `twenty api` operations out of scope
+
+| Operation | Status | Reason |
+| --- | --- | --- |
+| `create` | Out of scope | Mutation |
+| `update` | Out of scope | Mutation |
+| `delete` | Out of scope | Mutation |
+| `destroy` | Out of scope | Mutation |
+| `restore` | Out of scope | Mutation |
+| `batch-create` | Out of scope | Mutation |
+| `batch-update` | Out of scope | Mutation |
+| `batch-delete` | Out of scope | Mutation |
+| `import` | Out of scope | Mutation/import workflow |
+| `merge` | Out of scope | Mutation and server-side business logic |
+
+### `twenty api` deferred read-like operation
+
+| Operation | Status | Reason |
+| --- | --- | --- |
+| `find-duplicates` | Deferred | Read-only on paper, but dedupe semantics are business-logic-heavy and better left API-backed until parity is proven |
+
+## Included Data Surfaces
+
+The DB-first read platform should apply to record objects generally, not only
+to a short allowlist.
+
+Included object scope:
+
+- standard CRM objects such as people, companies, opportunities, tasks,
+  notes, favorites, attachments, and activity-like records where the CLI is
+  reading workspace record data
+- custom objects created in the active workspace
+- related records reachable through current `get`/`list` include-depth behavior
+
+Included relationship-heavy read scope:
+
+- person to company
+- company to people
+- opportunity relations
+- notes/tasks/attachments/favorites/activity relations
+- custom object relations
+- any relation surfaced through current record `depth` semantics once SQL
+  capability exists
+
+The principle is:
+
+- if a command is reading workspace record data and not mutating it, it should
+  be evaluated for DB-first support
+- if it is a control-plane or admin/config command, it remains API-backed
+
+## Phasing Recommendation
+
+Although the architectural scope is broad, implementation should still phase
+the work.
+
+Recommended order:
+
+1. core runtime and profile management
+2. `search`
+3. `api list`
+4. `api get` with relationship-heavy reads
+5. `api export`
+6. `api group-by`
+7. deferred read-like surfaces such as `find-duplicates` only if parity is
+   worth the added complexity
+
+This keeps the public design broad while keeping the first implementation cuts
+safe.
+
+## Main Risks And Mitigations
+
+### Endpoint metadata gap in upstream proxy support
+
+Risk:
+
+- `postgres-proxy get` does not currently return proxy host/port/database
+  metadata
+
+Mitigation:
+
+- require one explicit endpoint target such as `TWENTY_DB_PROXY_URL`
+- keep that target cacheable in DB profiles
+
+### Output drift between DB and API paths
+
+Risk:
+
+- DB rows may not line up perfectly with current command payloads
+
+Mitigation:
+
+- adapt DB rows back into current service payloads
+- keep renderers unchanged
+- add contract tests for text and machine outputs
+
+### Credential staleness
+
+Risk:
+
+- cached proxy credentials may be revoked or rotated
+
+Mitigation:
+
+- refresh through `postgres-proxy get` when API auth is available
+- expose refresh/test/status commands
+- keep a narrow internal override for support debugging
+
+### Relationship complexity
+
+Risk:
+
+- include-depth and custom-object relations can drift from simple table reads
+
+Mitigation:
+
+- phase relationship-heavy reads after the core runtime exists
+- gate unsupported relation paths behind runtime capability checks
+- fall back through the shared backend only for unsupported read shapes
+
+### Scope creep into control-plane commands
+
+Risk:
+
+- broad "read everything from DB" ambition pulls the project into metadata,
+  workflows, and admin APIs
+
+Mitigation:
+
+- keep the boundary explicit: record-read platform only
+- preserve the excluded command-family list in this spec as the governing scope
+
+## Success Criteria
+
+The design is successful when:
+
+- supported read-only record commands use DB-first automatically when a usable
+  DB profile or DB target exists
+- normal commands do not expose public backend-mode flags
+- `postgres-proxy` is the preferred bootstrap path rather than manual raw DB
+  setup
+- multiple named DB profiles per workspace are supported
+- `.env` remains first-class
+- mutations remain API-only
+- the exhaustive included/excluded command inventory remains clear and stable

--- a/packages/twenty-sdk/package.json
+++ b/packages/twenty-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salmonumbrella/twenty-cli",
-  "version": "0.0.0-dev",
+  "version": "0.1.10",
   "private": false,
   "description": "CLI for Twenty CRM",
   "keywords": [
@@ -44,13 +44,15 @@
     "form-data": "^4.0.5",
     "fs-extra": "^11.2.0",
     "jmespath": "^0.16.0",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/jmespath": "^0.15.2",
     "@types/node": "^25.5.2",
     "@types/papaparse": "^5.3.14",
+    "@types/pg": "^8.20.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"
   },

--- a/packages/twenty-sdk/src/cli/__tests__/help.spec.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/help.spec.ts
@@ -563,6 +563,19 @@ describe("CLI help contracts", () => {
     }
   });
 
+  it("renders the direct database env var in root help text", async () => {
+    const program = buildProgram();
+    const write = vi.fn();
+
+    const handled = await maybeHandleInlineHelp(program, [], write);
+
+    expect(handled).toBe(true);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0][0]).toContain("TWENTY_DATABASE_URL");
+    expect(write.mock.calls[0][0]).toContain("Supported reads auto prefer DB");
+    expect(write.mock.calls[0][0]).not.toContain("TWENTY_DB_PROXY_URL");
+  });
+
   it("renders command help JSON without requiring positional operations", async () => {
     const program = buildProgram();
     const write = vi.fn();

--- a/packages/twenty-sdk/src/cli/__tests__/help.spec.ts
+++ b/packages/twenty-sdk/src/cli/__tests__/help.spec.ts
@@ -26,6 +26,7 @@ describe("CLI help contracts", () => {
     expect(help.subcommands.some((command) => command.name === "openapi")).toBe(true);
     expect(help.subcommands.some((command) => command.name === "routes")).toBe(true);
     expect(help.subcommands.some((command) => command.name === "mcp")).toBe(true);
+    expect(help.subcommands.some((command) => command.name === "db")).toBe(true);
     expect(help.exit_codes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ code: 0 }),
@@ -267,6 +268,17 @@ describe("CLI help contracts", () => {
       expect.arrayContaining(["get", "enable", "disable"]),
     );
     expect(help.examples).toContain("twenty postgres-proxy get --show-password");
+  });
+
+  it("builds command help JSON for db profile commands", () => {
+    const help = buildHelpJson(buildProgram(), ["db", "profile", "--help-json"]);
+
+    expect(help.kind).toBe("command");
+    expect(help.path).toEqual(["twenty", "db", "profile"]);
+    expect(help.subcommands.map((command) => command.name)).toEqual(
+      expect.arrayContaining(["init", "list", "show", "use", "test", "refresh-creds", "remove"]),
+    );
+    expect(help.operations).toEqual([]);
   });
 
   it.each([

--- a/packages/twenty-sdk/src/cli/commands/connected-accounts/connected-accounts.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/connected-accounts/connected-accounts.command.ts
@@ -102,7 +102,7 @@ export function registerConnectedAccountsCommand(program: Command): void {
             cursor: options.cursor,
           });
           await services.output.render(
-            response.data.map((row) => sanitizeConnectedAccount(row, options)),
+            response.data.map((row: unknown) => sanitizeConnectedAccount(row, options)),
             {
               format: globalOptions.output,
               query: globalOptions.query,

--- a/packages/twenty-sdk/src/cli/commands/db/__tests__/db.command.spec.ts
+++ b/packages/twenty-sdk/src/cli/commands/db/__tests__/db.command.spec.ts
@@ -22,7 +22,7 @@ describe("db command", () => {
 
   beforeEach(() => {
     delete process.env.TWENTY_DB_PROFILE;
-    delete process.env.TWENTY_DB_PROXY_URL;
+    delete process.env.TWENTY_DATABASE_URL;
     program = new Command();
     program.exitOverride();
     registerDbCommand(program);
@@ -75,7 +75,7 @@ describe("db command", () => {
   afterEach(() => {
     consoleSpy.mockRestore();
     delete process.env.TWENTY_DB_PROFILE;
-    delete process.env.TWENTY_DB_PROXY_URL;
+    delete process.env.TWENTY_DATABASE_URL;
     vi.clearAllMocks();
   });
 
@@ -125,7 +125,7 @@ describe("db command", () => {
     mockGetProfile.mockResolvedValue({
       name: "explicit",
       workspace: "prod",
-      proxyUrl: "http://localhost:4010",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       credentialSource: "manual",
     });
 
@@ -147,7 +147,7 @@ describe("db command", () => {
     mockGetProfile.mockResolvedValue({
       name: "cached",
       workspace: "prod",
-      proxyUrl: "http://localhost:4011",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       credentialSource: "manual",
     });
 
@@ -166,7 +166,7 @@ describe("db command", () => {
     mockGetProfile.mockResolvedValue({
       name: "status-profile",
       workspace: "prod",
-      proxyUrl: "http://localhost:4012",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       credentialSource: "manual",
     });
 
@@ -188,11 +188,11 @@ describe("db command", () => {
     );
   });
 
-  it("initializes a db profile from a proxy URL", async () => {
+  it("initializes a db profile from a database URL", async () => {
     mockInitProfile.mockResolvedValue({
       name: "readonly",
       workspace: "default",
-      proxyUrl: "http://localhost:4010",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       credentialSource: "manual",
       notes: "seeded",
     });
@@ -204,8 +204,8 @@ describe("db command", () => {
       "profile",
       "init",
       "readonly",
-      "--proxy-url",
-      "http://localhost:4010",
+      "--database-url",
+      "postgresql://db.example.com:5432/twenty",
       "--notes",
       "seeded",
     ]);
@@ -213,13 +213,13 @@ describe("db command", () => {
     expect(mockInitProfile).toHaveBeenCalledWith({
       workspace: undefined,
       name: "readonly",
-      proxyUrl: "http://localhost:4010",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       notes: "seeded",
     });
     expect(outputRender).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "readonly",
-        proxyUrl: "http://localhost:4010",
+        databaseUrl: "postgresql://db.example.com:5432/twenty",
         credentialSource: "manual",
         notes: "seeded",
       }),
@@ -229,12 +229,12 @@ describe("db command", () => {
     );
   });
 
-  it("uses TWENTY_DB_PROXY_URL when initializing a db profile", async () => {
-    process.env.TWENTY_DB_PROXY_URL = "http://localhost:4999";
+  it("uses TWENTY_DATABASE_URL when initializing a db profile", async () => {
+    process.env.TWENTY_DATABASE_URL = "postgresql://db.example.com:5432/twenty";
     mockInitProfile.mockResolvedValue({
       name: "cached",
       workspace: "default",
-      proxyUrl: "http://localhost:4999",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       credentialSource: "manual",
     });
 
@@ -243,7 +243,7 @@ describe("db command", () => {
     expect(mockInitProfile).toHaveBeenCalledWith({
       workspace: undefined,
       name: "cached",
-      proxyUrl: "http://localhost:4999",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
       notes: undefined,
     });
   });

--- a/packages/twenty-sdk/src/cli/commands/db/__tests__/db.command.spec.ts
+++ b/packages/twenty-sdk/src/cli/commands/db/__tests__/db.command.spec.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { registerDbCommand } from "../db.command";
+import { createCommandContext } from "../../../utilities/shared/context";
+
+vi.mock("../../../utilities/shared/context", () => ({
+  createCommandContext: vi.fn(),
+}));
+
+describe("db command", () => {
+  let program: Command;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let outputRender: ReturnType<typeof vi.fn>;
+  let mockStatus: ReturnType<typeof vi.fn>;
+  let mockListProfiles: ReturnType<typeof vi.fn>;
+  let mockInitProfile: ReturnType<typeof vi.fn>;
+  let mockGetProfile: ReturnType<typeof vi.fn>;
+  let mockSetActiveProfile: ReturnType<typeof vi.fn>;
+  let mockTest: ReturnType<typeof vi.fn>;
+  let mockRefreshCreds: ReturnType<typeof vi.fn>;
+  let mockRemoveProfile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    delete process.env.TWENTY_DB_PROFILE;
+    delete process.env.TWENTY_DB_PROXY_URL;
+    program = new Command();
+    program.exitOverride();
+    registerDbCommand(program);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    outputRender = vi.fn();
+    mockStatus = vi.fn();
+    mockListProfiles = vi.fn();
+    mockInitProfile = vi.fn();
+    mockGetProfile = vi.fn();
+    mockSetActiveProfile = vi.fn();
+    mockTest = vi.fn();
+    mockRefreshCreds = vi.fn();
+    mockRemoveProfile = vi.fn();
+
+    vi.mocked(createCommandContext).mockImplementation(() => ({
+      globalOptions: {
+        output: "json",
+        query: undefined,
+        workspace: undefined,
+      },
+      services: {
+        config: {} as never,
+        api: {} as never,
+        publicHttp: {} as never,
+        search: {} as never,
+        mcp: {} as never,
+        records: {} as never,
+        metadata: {} as never,
+        output: {
+          render: outputRender,
+        } as never,
+        importer: {} as never,
+        exporter: {} as never,
+        dbStatus: {
+          getStatus: mockStatus,
+        } as never,
+        dbProfiles: {
+          listProfiles: mockListProfiles,
+          initProfile: mockInitProfile,
+          getProfile: mockGetProfile,
+          setActiveProfile: mockSetActiveProfile,
+          test: mockTest,
+          refreshCreds: mockRefreshCreds,
+          removeProfile: mockRemoveProfile,
+        } as never,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    delete process.env.TWENTY_DB_PROFILE;
+    delete process.env.TWENTY_DB_PROXY_URL;
+    vi.clearAllMocks();
+  });
+
+  it("registers the db command family", () => {
+    const command = program.commands.find((candidate) => candidate.name() === "db");
+    const profile = command?.commands.find((candidate) => candidate.name() === "profile");
+    const help = command?.helpInformation() ?? "";
+
+    expect(command).toBeDefined();
+    expect(command?.description()).toBe("Manage db-first read profiles and diagnostics");
+    expect(command?.commands.map((candidate) => candidate.name())).toEqual(
+      expect.arrayContaining(["profile", "status"]),
+    );
+    expect(profile?.commands.map((candidate) => candidate.name())).toEqual(
+      expect.arrayContaining(["init", "list", "show", "use", "test", "refresh-creds", "remove"]),
+    );
+    expect(help).toContain("profile");
+    expect(help).toContain("status");
+  });
+
+  it("shows db status via the status service", async () => {
+    mockStatus.mockResolvedValue({
+      workspace: "prod",
+      configured: true,
+      mode: "db",
+      profileName: "readonly",
+    });
+
+    await program.parseAsync(["node", "test", "db", "status"]);
+
+    expect(mockStatus).toHaveBeenCalledWith({ workspace: undefined });
+    expect(outputRender).toHaveBeenCalledWith(
+      {
+        workspace: "prod",
+        configured: true,
+        mode: "db",
+        profileName: "readonly",
+      },
+      {
+        format: "json",
+        query: undefined,
+      },
+    );
+  });
+
+  it("prefers an explicit db profile name when showing a profile", async () => {
+    mockGetProfile.mockResolvedValue({
+      name: "explicit",
+      workspace: "prod",
+      proxyUrl: "http://localhost:4010",
+      credentialSource: "manual",
+    });
+
+    await program.parseAsync(["node", "test", "db", "profile", "show", "explicit"]);
+
+    expect(mockGetProfile).toHaveBeenCalledWith(undefined, "explicit");
+    expect(outputRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "explicit",
+      }),
+      expect.objectContaining({
+        format: "json",
+      }),
+    );
+  });
+
+  it("falls back to TWENTY_DB_PROFILE when showing a profile", async () => {
+    process.env.TWENTY_DB_PROFILE = "cached";
+    mockGetProfile.mockResolvedValue({
+      name: "cached",
+      workspace: "prod",
+      proxyUrl: "http://localhost:4011",
+      credentialSource: "manual",
+    });
+
+    await program.parseAsync(["node", "test", "db", "profile", "show"]);
+
+    expect(mockGetProfile).toHaveBeenCalledWith(undefined, "cached");
+  });
+
+  it("falls back to the status profile when showing a profile", async () => {
+    mockStatus.mockResolvedValue({
+      workspace: "prod",
+      configured: true,
+      mode: "db",
+      profileName: "status-profile",
+    });
+    mockGetProfile.mockResolvedValue({
+      name: "status-profile",
+      workspace: "prod",
+      proxyUrl: "http://localhost:4012",
+      credentialSource: "manual",
+    });
+
+    await program.parseAsync(["node", "test", "db", "profile", "show"]);
+
+    expect(mockStatus).toHaveBeenCalledWith({ workspace: undefined });
+    expect(mockGetProfile).toHaveBeenCalledWith(undefined, "status-profile");
+  });
+
+  it("fails clearly when no profile can be resolved for show", async () => {
+    mockStatus.mockResolvedValue({
+      workspace: "prod",
+      configured: false,
+      mode: "api",
+    });
+
+    await expect(program.parseAsync(["node", "test", "db", "profile", "show"])).rejects.toThrow(
+      "No DB profile selected.",
+    );
+  });
+
+  it("initializes a db profile from a proxy URL", async () => {
+    mockInitProfile.mockResolvedValue({
+      name: "readonly",
+      workspace: "default",
+      proxyUrl: "http://localhost:4010",
+      credentialSource: "manual",
+      notes: "seeded",
+    });
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "db",
+      "profile",
+      "init",
+      "readonly",
+      "--proxy-url",
+      "http://localhost:4010",
+      "--notes",
+      "seeded",
+    ]);
+
+    expect(mockInitProfile).toHaveBeenCalledWith({
+      workspace: undefined,
+      name: "readonly",
+      proxyUrl: "http://localhost:4010",
+      notes: "seeded",
+    });
+    expect(outputRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "readonly",
+        proxyUrl: "http://localhost:4010",
+        credentialSource: "manual",
+        notes: "seeded",
+      }),
+      expect.objectContaining({
+        format: "json",
+      }),
+    );
+  });
+
+  it("uses TWENTY_DB_PROXY_URL when initializing a db profile", async () => {
+    process.env.TWENTY_DB_PROXY_URL = "http://localhost:4999";
+    mockInitProfile.mockResolvedValue({
+      name: "cached",
+      workspace: "default",
+      proxyUrl: "http://localhost:4999",
+      credentialSource: "manual",
+    });
+
+    await program.parseAsync(["node", "test", "db", "profile", "init", "cached"]);
+
+    expect(mockInitProfile).toHaveBeenCalledWith({
+      workspace: undefined,
+      name: "cached",
+      proxyUrl: "http://localhost:4999",
+      notes: undefined,
+    });
+  });
+});

--- a/packages/twenty-sdk/src/cli/commands/db/db.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/db/db.command.ts
@@ -5,7 +5,7 @@ import { createCommandContext } from "../../utilities/shared/context";
 import { registerCommand } from "../../utilities/shared/register-command";
 
 interface DbProfileInitOptions {
-  proxyUrl?: string;
+  databaseUrl?: string;
   notes?: string;
 }
 
@@ -38,25 +38,25 @@ export function registerDbCommand(program: Command): void {
 
   registerCommand(profileCmd, "init", "Initialize a db profile", (command) => {
     command.argument("<name>", "Profile name");
-    command.option("--proxy-url <url>", "DB proxy URL");
+    command.option("--database-url <url>", "Database URL");
     command.option("--notes <text>", "Profile notes");
     applyGlobalOptions(command);
     command.action(async (name: string, options: DbProfileInitOptions, actionCommand: Command) => {
       const { globalOptions, services } = createCommandContext(actionCommand);
-      const proxyUrl = options.proxyUrl ?? process.env.TWENTY_DB_PROXY_URL;
+      const databaseUrl = options.databaseUrl ?? process.env.TWENTY_DATABASE_URL;
 
-      if (!proxyUrl) {
+      if (!databaseUrl) {
         throw new CliError(
-          "Missing DB proxy URL.",
+          "Missing database URL.",
           "INVALID_ARGUMENTS",
-          'Provide --proxy-url or set TWENTY_DB_PROXY_URL.',
+          "Provide --database-url or set TWENTY_DATABASE_URL.",
         );
       }
 
       const profile = await services.dbProfiles.initProfile({
         workspace: globalOptions.workspace,
         name,
-        proxyUrl,
+        databaseUrl,
         notes: options.notes,
       });
 
@@ -86,9 +86,10 @@ export function registerDbCommand(program: Command): void {
     command.action(async (name: string | undefined, _options: unknown, actionCommand: Command) => {
       const { globalOptions, services } = createCommandContext(actionCommand);
       const envName = process.env.TWENTY_DB_PROFILE;
-      const resolvedStatus = name || envName
-        ? undefined
-        : await services.dbStatus.getStatus({ workspace: globalOptions.workspace });
+      const resolvedStatus =
+        name || envName
+          ? undefined
+          : await services.dbStatus.getStatus({ workspace: globalOptions.workspace });
       const resolvedName = resolveProfileName(name, envName, resolvedStatus?.profileName);
 
       if (!resolvedName) {

--- a/packages/twenty-sdk/src/cli/commands/db/db.command.ts
+++ b/packages/twenty-sdk/src/cli/commands/db/db.command.ts
@@ -1,0 +1,201 @@
+import { Command } from "commander";
+import { CliError } from "../../utilities/errors/cli-error";
+import { applyGlobalOptions } from "../../utilities/shared/global-options";
+import { createCommandContext } from "../../utilities/shared/context";
+import { registerCommand } from "../../utilities/shared/register-command";
+
+interface DbProfileInitOptions {
+  proxyUrl?: string;
+  notes?: string;
+}
+
+function resolveProfileName(
+  explicitName: string | undefined,
+  envName: string | undefined,
+  statusName: string | undefined,
+): string | undefined {
+  return explicitName || envName || statusName;
+}
+
+export function registerDbCommand(program: Command): void {
+  const db = program.command("db").description("Manage db-first read profiles and diagnostics");
+  applyGlobalOptions(db);
+
+  const statusCmd = db.command("status").description("Show db-first read diagnostics");
+  applyGlobalOptions(statusCmd);
+  statusCmd.action(async (_options: unknown, command: Command) => {
+    const { globalOptions, services } = createCommandContext(command);
+    const status = await services.dbStatus.getStatus({ workspace: globalOptions.workspace });
+
+    await services.output.render(status, {
+      format: globalOptions.output,
+      query: globalOptions.query,
+    });
+  });
+
+  const profileCmd = db.command("profile").description("cached db profiles");
+  applyGlobalOptions(profileCmd);
+
+  registerCommand(profileCmd, "init", "Initialize a db profile", (command) => {
+    command.argument("<name>", "Profile name");
+    command.option("--proxy-url <url>", "DB proxy URL");
+    command.option("--notes <text>", "Profile notes");
+    applyGlobalOptions(command);
+    command.action(async (name: string, options: DbProfileInitOptions, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      const proxyUrl = options.proxyUrl ?? process.env.TWENTY_DB_PROXY_URL;
+
+      if (!proxyUrl) {
+        throw new CliError(
+          "Missing DB proxy URL.",
+          "INVALID_ARGUMENTS",
+          'Provide --proxy-url or set TWENTY_DB_PROXY_URL.',
+        );
+      }
+
+      const profile = await services.dbProfiles.initProfile({
+        workspace: globalOptions.workspace,
+        name,
+        proxyUrl,
+        notes: options.notes,
+      });
+
+      await services.output.render(profile, {
+        format: globalOptions.output,
+        query: globalOptions.query,
+      });
+    });
+  });
+
+  registerCommand(profileCmd, "list", "List db profiles", (command) => {
+    applyGlobalOptions(command);
+    command.action(async (_options: unknown, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      const profiles = await services.dbProfiles.listProfiles(globalOptions.workspace);
+
+      await services.output.render(profiles, {
+        format: globalOptions.output,
+        query: globalOptions.query,
+      });
+    });
+  });
+
+  registerCommand(profileCmd, "show", "Show a db profile", (command) => {
+    command.argument("[name]", "Profile name");
+    applyGlobalOptions(command);
+    command.action(async (name: string | undefined, _options: unknown, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      const envName = process.env.TWENTY_DB_PROFILE;
+      const resolvedStatus = name || envName
+        ? undefined
+        : await services.dbStatus.getStatus({ workspace: globalOptions.workspace });
+      const resolvedName = resolveProfileName(name, envName, resolvedStatus?.profileName);
+
+      if (!resolvedName) {
+        throw new CliError(
+          "No DB profile selected.",
+          "INVALID_ARGUMENTS",
+          'Use "twenty db profile use <name>" or set TWENTY_DB_PROFILE.',
+        );
+      }
+
+      const profile = await services.dbProfiles.getProfile(globalOptions.workspace, resolvedName);
+
+      await services.output.render(profile, {
+        format: globalOptions.output,
+        query: globalOptions.query,
+      });
+    });
+  });
+
+  registerCommand(profileCmd, "use", "Set the active db profile", (command) => {
+    command.argument("<name>", "Profile name");
+    applyGlobalOptions(command);
+    command.action(async (name: string, _options: unknown, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      const profile = await services.dbProfiles.setActiveProfile(globalOptions.workspace, name);
+
+      await services.output.render(profile, {
+        format: globalOptions.output,
+        query: globalOptions.query,
+      });
+    });
+  });
+
+  registerCommand(profileCmd, "test", "Test a db profile", (command) => {
+    command.argument("[name]", "Profile name");
+    applyGlobalOptions(command);
+    command.action(async (name: string | undefined, _options: unknown, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      const resolved = await resolveDbProfileSelection(services, globalOptions.workspace, name);
+      const profile = await services.dbProfiles.test(globalOptions.workspace, resolved);
+
+      await services.output.render(profile, {
+        format: globalOptions.output,
+        query: globalOptions.query,
+      });
+    });
+  });
+
+  registerCommand(profileCmd, "refresh-creds", "Refresh db credentials", (command) => {
+    command.argument("[name]", "Profile name");
+    applyGlobalOptions(command);
+    command.action(async (name: string | undefined, _options: unknown, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      const resolved = await resolveDbProfileSelection(services, globalOptions.workspace, name);
+      const profile = await services.dbProfiles.refreshCreds(globalOptions.workspace, resolved);
+
+      await services.output.render(profile, {
+        format: globalOptions.output,
+        query: globalOptions.query,
+      });
+    });
+  });
+
+  registerCommand(profileCmd, "remove", "Remove a db profile", (command) => {
+    command.argument("<name>", "Profile name");
+    applyGlobalOptions(command);
+    command.action(async (name: string, _options: unknown, actionCommand: Command) => {
+      const { globalOptions, services } = createCommandContext(actionCommand);
+      await services.dbProfiles.removeProfile(globalOptions.workspace, name);
+
+      await services.output.render(
+        {
+          workspace: globalOptions.workspace,
+          name,
+          removed: true,
+        },
+        {
+          format: globalOptions.output,
+          query: globalOptions.query,
+        },
+      );
+    });
+  });
+}
+
+async function resolveDbProfileSelection(
+  services: ReturnType<typeof createCommandContext>["services"],
+  workspace: string | undefined,
+  explicitName: string | undefined,
+): Promise<string> {
+  if (explicitName) {
+    return explicitName;
+  }
+
+  const envName = process.env.TWENTY_DB_PROFILE;
+  if (envName) {
+    return envName;
+  }
+
+  const status = await services.dbStatus.getStatus({ workspace });
+  if (status.profileName) {
+    return status.profileName;
+  }
+
+  throw new CliError(
+    "No DB profile selected.",
+    "INVALID_ARGUMENTS",
+    'Use "twenty db profile use <name>" or set TWENTY_DB_PROFILE.',
+  );
+}

--- a/packages/twenty-sdk/src/cli/help.txt
+++ b/packages/twenty-sdk/src/cli/help.txt
@@ -21,6 +21,8 @@ Auth & Workspace:
   twenty auth status            Show the active auth/config state
   twenty auth workspace         Query the current workspace
   twenty auth discover ORIGIN   Discover a public workspace by domain
+  twenty db status              Show db-first read diagnostics
+  twenty db profile list        List cached db profiles
 
 Records:
   twenty api list people -o json
@@ -93,6 +95,8 @@ Environment:
   TWENTY_TOKEN                  API token
   TWENTY_BASE_URL               Base URL (default: https://api.twenty.com)
   TWENTY_PROFILE                Default workspace profile
+  TWENTY_DB_PROFILE             Default db profile
+  TWENTY_DB_PROXY_URL           Default db proxy URL
   TWENTY_OUTPUT                 Default output format
   TWENTY_QUERY                  Default JMESPath output filter
   TWENTY_ENV_FILE               Default explicit env file path

--- a/packages/twenty-sdk/src/cli/help.txt
+++ b/packages/twenty-sdk/src/cli/help.txt
@@ -27,8 +27,10 @@ Auth & Workspace:
 Records:
   twenty api list people -o json
   twenty api get companies RECORD_ID
+  twenty api group-by people --field city
   twenty api create notes --data '{"title":"Hello"}'
   twenty search "acme" --objects person,company
+  Supported reads auto prefer DB when TWENTY_DATABASE_URL or an active db profile is set; writes stay on the API
 
 Metadata & Admin:
   twenty api-metadata objects list
@@ -96,7 +98,7 @@ Environment:
   TWENTY_BASE_URL               Base URL (default: https://api.twenty.com)
   TWENTY_PROFILE                Default workspace profile
   TWENTY_DB_PROFILE             Default db profile
-  TWENTY_DB_PROXY_URL           Default db proxy URL
+  TWENTY_DATABASE_URL           Default database URL
   TWENTY_OUTPUT                 Default output format
   TWENTY_QUERY                  Default JMESPath output filter
   TWENTY_ENV_FILE               Default explicit env file path

--- a/packages/twenty-sdk/src/cli/help/constants.ts
+++ b/packages/twenty-sdk/src/cli/help/constants.ts
@@ -23,6 +23,12 @@ Integrations:
   twenty mcp schema find_companies
   twenty mcp exec find_companies --data '{"query":"Acme"}'
 
+Environment:
+  TWENTY_DATABASE_URL           Default database URL
+
+Records:
+  Supported reads auto prefer DB when TWENTY_DATABASE_URL or an active db profile is set; writes stay on the API.
+
 Raw Access:
   twenty openapi core
   twenty raw graphql query --document 'query { currentWorkspace { id } }'

--- a/packages/twenty-sdk/src/cli/program.ts
+++ b/packages/twenty-sdk/src/cli/program.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { registerApiCommand } from "./commands/api/api.command";
+import { registerDbCommand } from "./commands/db/db.command";
 import { registerApprovedAccessDomainsCommand } from "./commands/approved-access-domains/approved-access-domains.command";
 import { registerApiMetadataCommand } from "./commands/api-metadata/api-metadata.command";
 import { registerRawCommand } from "./commands/raw/raw.command";
@@ -38,6 +39,7 @@ export function buildProgram(): Command {
   program.exitOverride();
 
   registerApiCommand(program);
+  registerDbCommand(program);
   registerApprovedAccessDomainsCommand(program);
   registerApiMetadataCommand(program);
   registerRawCommand(program);

--- a/packages/twenty-sdk/src/cli/utilities/config/services/__tests__/config.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/config/services/__tests__/config.service.spec.ts
@@ -391,7 +391,7 @@ describe("ConfigService", () => {
       await service.saveDbProfile("prod", {
         name: "readonly",
         workspace: "prod",
-        proxyUrl: "http://localhost:4010",
+        databaseUrl: "postgresql://db.example.com:5432/twenty",
         credentialSource: "env",
       });
 
@@ -402,7 +402,7 @@ describe("ConfigService", () => {
       expect((savedConfig.workspaces?.prod as any).db.profiles.readonly).toEqual({
         name: "readonly",
         workspace: "prod",
-        proxyUrl: "http://localhost:4010",
+        databaseUrl: "postgresql://db.example.com:5432/twenty",
         credentialSource: "env",
       });
     });
@@ -419,13 +419,13 @@ describe("ConfigService", () => {
                 readonly: {
                   name: "readonly",
                   workspace: "prod",
-                  proxyUrl: "http://localhost:4010",
+                  databaseUrl: "postgresql://db.example.com:5432/twenty",
                   credentialSource: "env",
                 },
                 writer: {
                   name: "writer",
                   workspace: "prod",
-                  proxyUrl: "http://localhost:4011",
+                  databaseUrl: "postgresql://db.example.com:5432/twenty_writer",
                   credentialSource: "env",
                 },
               },
@@ -466,13 +466,13 @@ describe("ConfigService", () => {
                 readonly: {
                   name: "readonly",
                   workspace: "prod",
-                  proxyUrl: "http://localhost:4010",
+                  databaseUrl: "postgresql://db.example.com:5432/twenty",
                   credentialSource: "env",
                 },
                 writer: {
                   name: "writer",
                   workspace: "prod",
-                  proxyUrl: "http://localhost:4011",
+                  databaseUrl: "postgresql://db.example.com:5432/twenty_writer",
                   credentialSource: "env",
                 },
               },
@@ -490,13 +490,13 @@ describe("ConfigService", () => {
         {
           name: "readonly",
           workspace: "prod",
-          proxyUrl: "http://localhost:4010",
+          databaseUrl: "postgresql://db.example.com:5432/twenty",
           credentialSource: "env",
         },
         {
           name: "writer",
           workspace: "prod",
-          proxyUrl: "http://localhost:4011",
+          databaseUrl: "postgresql://db.example.com:5432/twenty_writer",
           credentialSource: "env",
         },
       ]);
@@ -520,7 +520,7 @@ describe("ConfigService", () => {
                 readonly: {
                   name: "readonly",
                   workspace: "prod",
-                  proxyUrl: "http://localhost:4010",
+                  databaseUrl: "postgresql://db.example.com:5432/twenty",
                   credentialSource: "env",
                 },
               },

--- a/packages/twenty-sdk/src/cli/utilities/config/services/__tests__/config.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/config/services/__tests__/config.service.spec.ts
@@ -10,13 +10,21 @@ vi.mock("os");
 describe("ConfigService", () => {
   const mockHomedir = "/home/testuser";
   const mockConfigPath = `${mockHomedir}/.twenty/config.json`;
+  const envKeys = ["TWENTY_TOKEN", "TWENTY_BASE_URL", "TWENTY_PROFILE"] as const;
+  let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
+    originalEnv = process.env;
     vi.mocked(os.homedir).mockReturnValue(mockHomedir);
     vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    for (const key of envKeys) {
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
+    process.env = originalEnv;
     vi.restoreAllMocks();
   });
 
@@ -109,11 +117,7 @@ describe("ConfigService", () => {
     });
 
     it("resolves apiUrl from TWENTY_BASE_URL without requiring auth", async () => {
-      const originalEnv = process.env;
-      process.env = {
-        ...originalEnv,
-        TWENTY_BASE_URL: "https://env.twenty.com",
-      };
+      process.env.TWENTY_BASE_URL = "https://env.twenty.com";
       vi.mocked(fs.pathExists).mockResolvedValue(false as never);
 
       const service = new ConfigService();
@@ -121,8 +125,6 @@ describe("ConfigService", () => {
 
       expect(result.apiUrl).toBe("https://env.twenty.com");
       expect(result.apiKey).toBe("");
-
-      process.env = originalEnv;
     });
 
     it("throws the selected workspace auth guidance when auth is required and missing", async () => {
@@ -370,6 +372,175 @@ describe("ConfigService", () => {
       expect(savedConfig.workspaces?.beta).toBeUndefined();
       // Should pick one of the remaining workspaces as default
       expect(["alpha", "gamma"]).toContain(savedConfig.defaultWorkspace);
+    });
+  });
+
+  describe("db profiles", () => {
+    it("stores named db profiles under a workspace", async () => {
+      const config = {
+        workspaces: {
+          prod: { apiKey: "key1", apiUrl: "https://api.twenty.com" },
+        },
+        defaultWorkspace: "prod",
+      } as TwentyConfigFile;
+      vi.mocked(fs.pathExists).mockResolvedValue(true as never);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(config) as never);
+      vi.mocked(fs.outputFile).mockResolvedValue(undefined as never);
+
+      const service = new ConfigService();
+      await service.saveDbProfile("prod", {
+        name: "readonly",
+        workspace: "prod",
+        proxyUrl: "http://localhost:4010",
+        credentialSource: "env",
+      });
+
+      const savedConfig = JSON.parse(
+        vi.mocked(fs.outputFile).mock.calls[0][1] as string,
+      ) as TwentyConfigFile;
+
+      expect((savedConfig.workspaces?.prod as any).db.profiles.readonly).toEqual({
+        name: "readonly",
+        workspace: "prod",
+        proxyUrl: "http://localhost:4010",
+        credentialSource: "env",
+      });
+    });
+
+    it("switches active db profile without changing api config", async () => {
+      const config = {
+        workspaces: {
+          prod: {
+            apiKey: "key1",
+            apiUrl: "https://api.twenty.com",
+            db: {
+              activeProfile: "readonly",
+              profiles: {
+                readonly: {
+                  name: "readonly",
+                  workspace: "prod",
+                  proxyUrl: "http://localhost:4010",
+                  credentialSource: "env",
+                },
+                writer: {
+                  name: "writer",
+                  workspace: "prod",
+                  proxyUrl: "http://localhost:4011",
+                  credentialSource: "env",
+                },
+              },
+            },
+          },
+        },
+        defaultWorkspace: "prod",
+      } as TwentyConfigFile;
+      vi.mocked(fs.pathExists).mockResolvedValue(true as never);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(config) as never);
+      vi.mocked(fs.outputFile).mockResolvedValue(undefined as never);
+
+      const service = new ConfigService();
+      const before = await service.resolveApiConfig({ workspace: "prod", requireAuth: false });
+      await service.setActiveDbProfile("prod", "writer");
+      const after = await service.resolveApiConfig({ workspace: "prod", requireAuth: false });
+
+      expect(before).toEqual(after);
+      expect(before).toEqual({
+        apiUrl: "https://api.twenty.com",
+        apiKey: "key1",
+        workspace: "prod",
+      });
+      const savedConfig = JSON.parse(
+        vi.mocked(fs.outputFile).mock.calls[0][1] as string,
+      ) as TwentyConfigFile;
+      expect((savedConfig.workspaces?.prod as any).db.activeProfile).toBe("writer");
+    });
+
+    it("lists and removes db profiles", async () => {
+      const config = {
+        workspaces: {
+          prod: {
+            apiKey: "key1",
+            db: {
+              activeProfile: "readonly",
+              profiles: {
+                readonly: {
+                  name: "readonly",
+                  workspace: "prod",
+                  proxyUrl: "http://localhost:4010",
+                  credentialSource: "env",
+                },
+                writer: {
+                  name: "writer",
+                  workspace: "prod",
+                  proxyUrl: "http://localhost:4011",
+                  credentialSource: "env",
+                },
+              },
+            },
+          },
+        },
+        defaultWorkspace: "prod",
+      } as TwentyConfigFile;
+      vi.mocked(fs.pathExists).mockResolvedValue(true as never);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(config) as never);
+      vi.mocked(fs.outputFile).mockResolvedValue(undefined as never);
+
+      const service = new ConfigService();
+      expect(await service.listDbProfiles("prod")).toEqual([
+        {
+          name: "readonly",
+          workspace: "prod",
+          proxyUrl: "http://localhost:4010",
+          credentialSource: "env",
+        },
+        {
+          name: "writer",
+          workspace: "prod",
+          proxyUrl: "http://localhost:4011",
+          credentialSource: "env",
+        },
+      ]);
+
+      await service.removeDbProfile("prod", "writer");
+
+      const savedConfig = JSON.parse(
+        vi.mocked(fs.outputFile).mock.calls[0][1] as string,
+      ) as TwentyConfigFile;
+      expect((savedConfig.workspaces?.prod as any).db.profiles.writer).toBeUndefined();
+      expect((savedConfig.workspaces?.prod as any).db.activeProfile).toBe("readonly");
+    });
+
+    it("throws when setting an unknown active db profile", async () => {
+      const config = {
+        workspaces: {
+          prod: {
+            apiKey: "key1",
+            db: {
+              profiles: {
+                readonly: {
+                  name: "readonly",
+                  workspace: "prod",
+                  proxyUrl: "http://localhost:4010",
+                  credentialSource: "env",
+                },
+              },
+            },
+          },
+        },
+        defaultWorkspace: "prod",
+      } as TwentyConfigFile;
+      vi.mocked(fs.pathExists).mockResolvedValue(true as never);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(config) as never);
+
+      const service = new ConfigService();
+
+      await expect(service.setActiveDbProfile("prod", "writer")).rejects.toEqual(
+        new CliError(
+          "DB profile 'writer' does not exist in workspace 'prod'",
+          "INVALID_ARGUMENTS",
+          'Use "twenty db profile list" to see available profiles.',
+        ),
+      );
     });
   });
 });

--- a/packages/twenty-sdk/src/cli/utilities/config/services/config.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/config/services/config.service.ts
@@ -201,6 +201,13 @@ export class ConfigService {
 
   async saveDbProfile(workspace: string, profile: DbProfileConfig): Promise<void> {
     const config = await this.loadConfigFile();
+    if (!config) {
+      throw new CliError(
+        `Workspace '${workspace}' does not exist`,
+        "INVALID_ARGUMENTS",
+        'Use "twenty auth list" to see available workspaces.',
+      );
+    }
     const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
 
     if (!workspaceConfig.db) {
@@ -216,6 +223,13 @@ export class ConfigService {
 
   async setActiveDbProfile(workspace: string, name: string): Promise<void> {
     const config = await this.loadConfigFile();
+    if (!config) {
+      throw new CliError(
+        `Workspace '${workspace}' does not exist`,
+        "INVALID_ARGUMENTS",
+        'Use "twenty auth list" to see available workspaces.',
+      );
+    }
     const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
     this.getDbProfileFromWorkspaceConfig(workspaceConfig, workspace, name);
 
@@ -252,6 +266,13 @@ export class ConfigService {
 
   async removeDbProfile(workspace: string, name: string): Promise<void> {
     const config = await this.loadConfigFile();
+    if (!config) {
+      throw new CliError(
+        `Workspace '${workspace}' does not exist`,
+        "INVALID_ARGUMENTS",
+        'Use "twenty auth list" to see available workspaces.',
+      );
+    }
     const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
     const profiles = workspaceConfig.db?.profiles;
     if (!profiles || !profiles[name]) {

--- a/packages/twenty-sdk/src/cli/utilities/config/services/config.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/config/services/config.service.ts
@@ -6,6 +6,25 @@ import { CliError } from "../../errors/cli-error";
 export interface WorkspaceConfig {
   apiUrl?: string;
   apiKey?: string;
+  db?: WorkspaceDbConfig;
+}
+
+export interface DbProfileConfig {
+  name: string;
+  workspace: string;
+  workspaceId?: string;
+  proxyUrl: string;
+  credentialSource: string;
+  cachedUser?: string;
+  cachedPassword?: string;
+  lastRefreshedAt?: string;
+  lastValidatedAt?: string;
+  notes?: string;
+}
+
+export interface WorkspaceDbConfig {
+  activeProfile?: string;
+  profiles?: Record<string, DbProfileConfig>;
 }
 
 export interface TwentyConfigFile {
@@ -152,7 +171,10 @@ export class ConfigService {
       config.defaultWorkspace = name;
     }
 
-    config.workspaces[name] = workspaceConfig;
+    config.workspaces[name] = {
+      ...config.workspaces[name],
+      ...workspaceConfig,
+    };
     await this.saveConfigFile(config);
   }
 
@@ -177,7 +199,113 @@ export class ConfigService {
     await this.saveConfigFile(config);
   }
 
+  async saveDbProfile(workspace: string, profile: DbProfileConfig): Promise<void> {
+    const config = await this.loadConfigFile();
+    const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
+
+    if (!workspaceConfig.db) {
+      workspaceConfig.db = {};
+    }
+    if (!workspaceConfig.db.profiles) {
+      workspaceConfig.db.profiles = {};
+    }
+
+    workspaceConfig.db.profiles[profile.name] = profile;
+    await this.saveConfigFile(config);
+  }
+
+  async setActiveDbProfile(workspace: string, name: string): Promise<void> {
+    const config = await this.loadConfigFile();
+    const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
+    this.getDbProfileFromWorkspaceConfig(workspaceConfig, workspace, name);
+
+    if (!workspaceConfig.db) {
+      workspaceConfig.db = {};
+    }
+
+    workspaceConfig.db.activeProfile = name;
+    await this.saveConfigFile(config);
+  }
+
+  async getDbProfile(workspace: string, name: string): Promise<DbProfileConfig> {
+    const config = await this.loadConfigFile();
+    const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
+    return this.getDbProfileFromWorkspaceConfig(workspaceConfig, workspace, name);
+  }
+
+  async getActiveDbProfile(workspace: string): Promise<DbProfileConfig | undefined> {
+    const config = await this.loadConfigFile();
+    const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
+    const activeProfile = workspaceConfig.db?.activeProfile;
+    if (!activeProfile) {
+      return undefined;
+    }
+
+    return this.getDbProfileFromWorkspaceConfig(workspaceConfig, workspace, activeProfile);
+  }
+
+  async listDbProfiles(workspace: string): Promise<DbProfileConfig[]> {
+    const config = await this.loadConfigFile();
+    const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
+    return Object.values(workspaceConfig.db?.profiles ?? {});
+  }
+
+  async removeDbProfile(workspace: string, name: string): Promise<void> {
+    const config = await this.loadConfigFile();
+    const workspaceConfig = this.ensureWorkspaceExists(config, workspace);
+    const profiles = workspaceConfig.db?.profiles;
+    if (!profiles || !profiles[name]) {
+      throw new CliError(
+        `DB profile '${name}' does not exist in workspace '${workspace}'`,
+        "INVALID_ARGUMENTS",
+        'Use "twenty db profile list" to see available profiles.',
+      );
+    }
+
+    delete profiles[name];
+
+    if (workspaceConfig.db?.activeProfile === name) {
+      const remainingProfiles = Object.keys(profiles);
+      workspaceConfig.db.activeProfile = remainingProfiles[0];
+    }
+
+    await this.saveConfigFile(config);
+  }
+
   private async saveConfigFile(config: TwentyConfigFile): Promise<void> {
     await fs.outputFile(this.configPath, JSON.stringify(config, null, 2), "utf-8");
+  }
+
+  private ensureWorkspaceExists(
+    config: TwentyConfigFile | null,
+    workspace: string,
+  ): WorkspaceConfig {
+    const workspaceConfig = config?.workspaces?.[workspace];
+    if (!config?.workspaces || !workspaceConfig) {
+      throw new CliError(
+        `Workspace '${workspace}' does not exist`,
+        "INVALID_ARGUMENTS",
+        'Use "twenty auth list" to see available workspaces.',
+      );
+    }
+
+    return workspaceConfig;
+  }
+
+  private getDbProfileFromWorkspaceConfig(
+    workspaceConfig: WorkspaceConfig,
+    workspace: string,
+    name: string,
+  ): DbProfileConfig {
+    const profile = workspaceConfig.db?.profiles?.[name];
+    if (!profile) {
+      throw new CliError(
+        `DB profile '${name}' does not exist in workspace '${workspace}'`,
+        "INVALID_ARGUMENTS",
+        'Use "twenty db profile list" to see available profiles.',
+      );
+    }
+
+    return profile;
   }
 }

--- a/packages/twenty-sdk/src/cli/utilities/config/services/config.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/config/services/config.service.ts
@@ -13,7 +13,7 @@ export interface DbProfileConfig {
   name: string;
   workspace: string;
   workspaceId?: string;
-  proxyUrl: string;
+  databaseUrl: string;
   credentialSource: string;
   cachedUser?: string;
   cachedPassword?: string;

--- a/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-config-resolver.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-config-resolver.service.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DbConfigResolverService } from "../db-config-resolver.service";
+
+describe("DbConfigResolverService", () => {
+  afterEach(() => {
+    delete process.env.TWENTY_INTERNAL_READ_BACKEND;
+    delete process.env.TWENTY_DATABASE_URL;
+    vi.clearAllMocks();
+  });
+
+  it("prefers the internal api override over any db configuration while preserving profile context", async () => {
+    process.env.TWENTY_INTERNAL_READ_BACKEND = "api";
+    process.env.TWENTY_DATABASE_URL = "postgresql://env-user:env-pass@db.example.com:5432/twenty";
+
+    const dbProfiles = {
+      resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+      getActiveProfile: vi.fn().mockResolvedValue({
+        name: "staging",
+        workspace: "prod",
+        databaseUrl: "postgresql://profile-user:profile-pass@db.example.com:5432/twenty_staging",
+      }),
+    };
+
+    const resolver = new DbConfigResolverService(dbProfiles as never);
+
+    await expect(resolver.resolve({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      mode: "api",
+      source: "override",
+      profileName: "staging",
+    });
+    expect(dbProfiles.getActiveProfile).toHaveBeenCalledWith("prod");
+  });
+
+  it("prefers TWENTY_DATABASE_URL over the saved active db profile", async () => {
+    process.env.TWENTY_DATABASE_URL = "postgresql://env-user:env-pass@db.example.com:5432/twenty";
+
+    const resolver = new DbConfigResolverService({
+      resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+      getActiveProfile: vi.fn().mockResolvedValue({
+        name: "staging",
+        workspace: "prod",
+        databaseUrl: "postgresql://profile-user:profile-pass@db.example.com:5432/twenty_staging",
+      }),
+    } as never);
+
+    await expect(resolver.resolve({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      mode: "db",
+      source: "env",
+      databaseUrl: "postgresql://env-user:env-pass@db.example.com:5432/twenty",
+    });
+  });
+
+  it("uses the saved active db profile when no env database url is set", async () => {
+    const resolver = new DbConfigResolverService({
+      resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+      getActiveProfile: vi.fn().mockResolvedValue({
+        name: "staging",
+        workspace: "prod",
+        databaseUrl: "postgresql://profile-user:profile-pass@db.example.com:5432/twenty_staging",
+      }),
+    } as never);
+
+    await expect(resolver.resolve({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      mode: "db",
+      source: "profile",
+      databaseUrl: "postgresql://profile-user:profile-pass@db.example.com:5432/twenty_staging",
+      profileName: "staging",
+    });
+  });
+
+  it("falls back to api mode when no db configuration exists", async () => {
+    const resolver = new DbConfigResolverService({
+      resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+      getActiveProfile: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    await expect(resolver.resolve({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      mode: "api",
+      source: "none",
+    });
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-records-read.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-records-read.service.spec.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vitest";
+import { DbRecordsReadService } from "../db-records-read.service";
+import { UnsupportedDbReadError } from "../../../readbackend/types";
+
+const DB_TARGET = {
+  mode: "db",
+  source: "env",
+  workspace: "default",
+  databaseUrl: "postgresql://reader:secret@db.example.com:5432/twenty?sslmode=require",
+} as const;
+
+describe("DbRecordsReadService", () => {
+  it("returns the existing ListResponse shape for db-backed list reads", async () => {
+    const planner = {
+      planObject: vi.fn().mockResolvedValue({
+        objectMetadata: { id: "person-id", nameSingular: "person", namePlural: "people" },
+        tableName: "person",
+        includes: [],
+      }),
+    };
+    const filterCompiler = {
+      compile: vi.fn().mockReturnValue([
+        { field: "status", operator: "eq", value: "ACTIVE" },
+        { field: "score", operator: "gte", value: 10 },
+      ]),
+    };
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ totalCount: "3" }] })
+        .mockResolvedValueOnce({
+          rows: [
+            { rowData: { id: "person-1", name: "Ada", status: "ACTIVE" } },
+            { rowData: { id: "person-2", name: "Grace", status: "ACTIVE" } },
+          ],
+        }),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const dbConnection = {
+      connect: vi.fn().mockResolvedValue(client),
+    };
+    const service = new DbRecordsReadService(
+      {} as never,
+      planner as never,
+      filterCompiler as never,
+      dbConnection as never,
+    );
+
+    const result = await service.list(DB_TARGET, "people", {
+      limit: 2,
+      filter: "status[eq]:ACTIVE;score[gte]:10",
+      sort: "createdAt",
+      order: "desc",
+    });
+
+    expect(dbConnection.connect).toHaveBeenCalledWith({
+      databaseUrl: "postgresql://reader:secret@db.example.com:5432/twenty?sslmode=require",
+    });
+    expect(planner.planObject).toHaveBeenCalledWith("people", { include: undefined });
+    expect(filterCompiler.compile).toHaveBeenCalledWith("status[eq]:ACTIVE;score[gte]:10");
+
+    const queries = client.query.mock.calls.map(([sql, params]) => ({
+      sql: String(sql),
+      params,
+    }));
+
+    expect(queries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: expect.stringContaining('from "person" as t'),
+          params: ["ACTIVE", 10],
+        }),
+        expect.objectContaining({
+          sql: expect.stringContaining('order by t."createdAt" desc nulls last, t."id" asc'),
+          params: ["ACTIVE", 10, 2, 0],
+        }),
+      ]),
+    );
+    expect(result).toEqual({
+      data: [
+        { id: "person-1", name: "Ada", status: "ACTIVE" },
+        { id: "person-2", name: "Grace", status: "ACTIVE" },
+      ],
+      totalCount: 3,
+      pageInfo: {
+        hasNextPage: true,
+        endCursor: "db:1",
+      },
+    });
+  });
+
+  it("accumulates rows across db pages for listAll", async () => {
+    const planner = {
+      planObject: vi.fn().mockResolvedValue({
+        objectMetadata: { id: "person-id", nameSingular: "person", namePlural: "people" },
+        tableName: "person",
+        includes: [],
+      }),
+    };
+    const filterCompiler = {
+      compile: vi.fn().mockReturnValue([]),
+    };
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ totalCount: "2" }] })
+        .mockResolvedValueOnce({ rows: [{ rowData: { id: "person-1", name: "Ada" } }] })
+        .mockResolvedValueOnce({ rows: [{ totalCount: "2" }] })
+        .mockResolvedValueOnce({ rows: [{ rowData: { id: "person-2", name: "Grace" } }] }),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const dbConnection = {
+      connect: vi.fn().mockResolvedValue(client),
+    };
+    const service = new DbRecordsReadService(
+      {} as never,
+      planner as never,
+      filterCompiler as never,
+      dbConnection as never,
+    );
+
+    const result = await service.listAll(DB_TARGET, "people", { limit: 1 });
+
+    expect(result).toEqual({
+      data: [
+        { id: "person-1", name: "Ada" },
+        { id: "person-2", name: "Grace" },
+      ],
+      totalCount: 2,
+      pageInfo: {
+        hasNextPage: false,
+        endCursor: "db:1",
+      },
+    });
+  });
+
+  it("hydrates MANY_TO_ONE includes for get", async () => {
+    const planner = {
+      planObject: vi.fn().mockResolvedValue({
+        objectMetadata: { id: "person-id", nameSingular: "person", namePlural: "people" },
+        tableName: "person",
+        includes: [
+          {
+            relationName: "company",
+            joinColumnName: "companyId",
+            fieldMetadata: { id: "field-1" },
+            objectMetadata: { id: "company-id", nameSingular: "company", namePlural: "companies" },
+            tableName: "company",
+          },
+        ],
+      }),
+    };
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ rowData: { id: "person-1", companyId: "company-1" } }] })
+        .mockResolvedValueOnce({ rows: [{ rowData: { id: "company-1", name: "Acme" } }] }),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const dbConnection = {
+      connect: vi.fn().mockResolvedValue(client),
+    };
+    const service = new DbRecordsReadService(
+      {} as never,
+      planner as never,
+      undefined,
+      dbConnection as never,
+    );
+
+    const result = await service.get(DB_TARGET, "people", "person-1", { include: "company" });
+
+    expect(result).toEqual({
+      id: "person-1",
+      companyId: "company-1",
+      company: {
+        id: "company-1",
+        name: "Acme",
+      },
+    });
+  });
+
+  it("maps DB groupBy rows into the existing response shape", async () => {
+    const planner = {
+      planObject: vi.fn().mockResolvedValue({
+        objectMetadata: { id: "person-id", nameSingular: "person", namePlural: "people" },
+        tableName: "person",
+        includes: [],
+      }),
+    };
+    const filterCompiler = {
+      compile: vi.fn().mockReturnValue([{ field: "status", operator: "eq", value: "ACTIVE" }]),
+    };
+    const client = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ group_0: "London", countNotEmptyId: "2" }],
+      }),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const dbConnection = {
+      connect: vi.fn().mockResolvedValue(client),
+    };
+    const service = new DbRecordsReadService(
+      {} as never,
+      planner as never,
+      filterCompiler as never,
+      dbConnection as never,
+    );
+
+    const result = await service.groupBy(
+      DB_TARGET,
+      "people",
+      { groupBy: [{ city: true }], filter: "status[eq]:ACTIVE" },
+      { aggregate: ["totalCount"], limit: ["5"] },
+    );
+
+    expect(result).toEqual([
+      {
+        groupByDimensionValues: ["London"],
+        countNotEmptyId: "2",
+      },
+    ]);
+  });
+
+  it("rejects include hydration on list reads", async () => {
+    const service = new DbRecordsReadService({} as never);
+
+    await expect(service.list(DB_TARGET, "people", { include: "company" })).rejects.toBeInstanceOf(
+      UnsupportedDbReadError,
+    );
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-search.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-search.service.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { DbSearchService } from "../db-search.service";
+import { DbConnectionError, UnsupportedDbReadError } from "../../../readbackend/types";
+
+describe("DbSearchService", () => {
+  it("uses the resolved databaseUrl directly and maps the existing SearchResponse shape", async () => {
+    const metadata = {
+      listObjects: vi.fn().mockResolvedValue([
+        {
+          id: "person-id",
+          nameSingular: "person",
+          namePlural: "people",
+          labelSingular: "Person",
+        },
+      ]),
+    };
+    const client = {
+      query: vi.fn().mockResolvedValue({
+        rows: [
+          {
+            recordId: "person-1",
+            rowData: {
+              name: {
+                firstName: "Ada",
+                lastName: "Lovelace",
+              },
+              avatarUrl: "https://cdn.example.com/ada.png",
+            },
+            tsRankCD: 0.9,
+            tsRank: 0.8,
+          },
+        ],
+      }),
+      end: vi.fn().mockResolvedValue(undefined),
+    };
+    const dbConnection = {
+      connect: vi.fn().mockResolvedValue(client),
+    };
+    const service = new DbSearchService(metadata as never, undefined, dbConnection as never);
+
+    const result = await service.search(
+      {
+        mode: "db",
+        source: "env",
+        workspace: "default",
+        databaseUrl: "postgresql://reader:secret@db.example.com:5432/twenty?sslmode=require",
+      },
+      { query: "ada" },
+    );
+
+    expect(dbConnection.connect).toHaveBeenCalledWith({
+      databaseUrl: "postgresql://reader:secret@db.example.com:5432/twenty?sslmode=require",
+    });
+    expect(client.query).toHaveBeenCalledWith(expect.stringContaining('from "person"'), [
+      "ada",
+      21,
+    ]);
+    expect(result).toEqual({
+      data: [
+        {
+          recordId: "person-1",
+          objectNameSingular: "person",
+          objectLabelSingular: "Person",
+          label: "Ada Lovelace",
+          imageUrl: "https://cdn.example.com/ada.png",
+          tsRankCD: 0.9,
+          tsRank: 0.8,
+          cursor: "db:0",
+        },
+      ],
+      pageInfo: {
+        hasNextPage: false,
+        endCursor: "db:0",
+      },
+    });
+  });
+
+  it("rejects filters because DB search does not support them yet", async () => {
+    const service = new DbSearchService({
+      listObjects: vi.fn(),
+    } as never);
+
+    await expect(
+      service.search(
+        {
+          mode: "db",
+          source: "env",
+          workspace: "default",
+          databaseUrl: "postgresql://reader:secret@db.example.com:5432/twenty",
+        },
+        {
+          query: "ada",
+          filter: { city: { eq: "London" } },
+        },
+      ),
+    ).rejects.toBeInstanceOf(UnsupportedDbReadError);
+  });
+
+  it("maps connection failures to DbConnectionError", async () => {
+    const service = new DbSearchService(
+      {
+        listObjects: vi.fn().mockResolvedValue([
+          {
+            id: "person-id",
+            nameSingular: "person",
+            namePlural: "people",
+            labelSingular: "Person",
+          },
+        ]),
+      } as never,
+      undefined,
+      {
+        connect: vi.fn().mockRejectedValue(new Error("connect failed")),
+      } as never,
+    );
+
+    await expect(
+      service.search(
+        {
+          mode: "db",
+          source: "env",
+          workspace: "default",
+          databaseUrl: "postgresql://reader:secret@db.example.com:5432/twenty",
+        },
+        {
+          query: "ada",
+        },
+      ),
+    ).rejects.toBeInstanceOf(DbConnectionError);
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-status.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/__tests__/db-status.service.spec.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DbConfigResolverService } from "../db-config-resolver.service";
+import { DbStatusService } from "../db-status.service";
+
+describe("DbStatusService", () => {
+  afterEach(() => {
+    delete process.env.TWENTY_INTERNAL_READ_BACKEND;
+    delete process.env.TWENTY_DATABASE_URL;
+    vi.clearAllMocks();
+  });
+
+  it("reports env db configuration as the active db-first source", async () => {
+    const resolver = new DbConfigResolverService({
+      resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+      getActiveProfile: vi.fn().mockResolvedValue(undefined),
+    } as never);
+
+    process.env.TWENTY_DATABASE_URL = "postgresql://db.example.com:5432/twenty";
+    const service = new DbStatusService(resolver);
+
+    await expect(service.getStatus({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      configured: true,
+      mode: "db",
+      source: "env",
+    });
+  });
+
+  it("reports the active saved profile when db-first reads come from profile config", async () => {
+    const service = new DbStatusService(
+      new DbConfigResolverService({
+        resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+        getActiveProfile: vi.fn().mockResolvedValue({
+          name: "staging",
+          workspace: "prod",
+          databaseUrl: "postgresql://db.example.com:5432/twenty",
+        }),
+      } as never),
+    );
+
+    await expect(service.getStatus({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      configured: true,
+      mode: "db",
+      source: "profile",
+      profileName: "staging",
+    });
+  });
+
+  it("reports api mode when the internal backend override disables db-first reads", async () => {
+    process.env.TWENTY_INTERNAL_READ_BACKEND = "api";
+    process.env.TWENTY_DATABASE_URL = "postgresql://db.example.com:5432/twenty";
+
+    const service = new DbStatusService(
+      new DbConfigResolverService({
+        resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+        getActiveProfile: vi.fn().mockResolvedValue({
+          name: "staging",
+          workspace: "prod",
+          databaseUrl: "postgresql://db.example.com:5432/twenty",
+        }),
+      } as never),
+    );
+
+    await expect(service.getStatus({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      configured: false,
+      mode: "api",
+      source: "override",
+      profileName: "staging",
+    });
+  });
+
+  it("reports api mode when no db configuration exists", async () => {
+    const service = new DbStatusService(
+      new DbConfigResolverService({
+        resolveWorkspace: vi.fn().mockResolvedValue("prod"),
+        getActiveProfile: vi.fn().mockResolvedValue(undefined),
+      } as never),
+    );
+
+    await expect(service.getStatus({ workspace: "prod" })).resolves.toEqual({
+      workspace: "prod",
+      configured: false,
+      mode: "api",
+      source: "none",
+    });
+  });
+
+  it("uses the resolver workspace even when no workspace option is passed", async () => {
+    const resolveWorkspace = vi.fn().mockResolvedValue("resolved-workspace");
+    const service = new DbStatusService(
+      new DbConfigResolverService({
+        resolveWorkspace,
+        getActiveProfile: vi.fn().mockResolvedValue({
+          name: "readonly",
+          workspace: "resolved-workspace",
+          databaseUrl: "postgresql://db.example.com:5432/twenty",
+        }),
+      } as never),
+    );
+
+    await expect(service.getStatus()).resolves.toEqual({
+      workspace: "resolved-workspace",
+      configured: true,
+      mode: "db",
+      source: "profile",
+      profileName: "readonly",
+    });
+    expect(resolveWorkspace).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-config-resolver.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-config-resolver.service.ts
@@ -1,0 +1,54 @@
+import { DbProfileService } from "./db-profile.service";
+
+export interface ResolvedDbConfig {
+  workspace: string;
+  mode: "api" | "db";
+  source: "env" | "profile" | "none" | "override";
+  databaseUrl?: string;
+  profileName?: string;
+}
+
+export class DbConfigResolverService {
+  constructor(private readonly dbProfiles: DbProfileService) {}
+
+  async resolve(options?: { workspace?: string }): Promise<ResolvedDbConfig> {
+    const workspace = await this.dbProfiles.resolveWorkspace(options?.workspace);
+    const activeProfile = await this.dbProfiles.getActiveProfile(workspace);
+
+    if (process.env.TWENTY_INTERNAL_READ_BACKEND === "api") {
+      return {
+        workspace,
+        mode: "api",
+        source: "override",
+        profileName: activeProfile?.name,
+      };
+    }
+
+    const envDatabaseUrl = process.env.TWENTY_DATABASE_URL?.trim();
+
+    if (envDatabaseUrl) {
+      return {
+        workspace,
+        mode: "db",
+        source: "env",
+        databaseUrl: envDatabaseUrl,
+      };
+    }
+
+    if (activeProfile?.databaseUrl) {
+      return {
+        workspace,
+        mode: "db",
+        source: "profile",
+        databaseUrl: activeProfile.databaseUrl,
+        profileName: activeProfile.name,
+      };
+    }
+
+    return {
+      workspace,
+      mode: "api",
+      source: "none",
+    };
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-connection.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-connection.service.ts
@@ -1,0 +1,26 @@
+import { Client } from "pg";
+
+export interface DbConnectionOptions {
+  databaseUrl: string;
+}
+
+export class DbConnectionService {
+  async connect(options: DbConnectionOptions): Promise<Client> {
+    const url = new URL(options.databaseUrl);
+    const sslmode = url.searchParams.get("sslmode");
+    const client = new Client({
+      connectionString: options.databaseUrl,
+      ssl: sslmode === "require" ? { rejectUnauthorized: false } : undefined,
+    });
+
+    await client.connect();
+
+    return client;
+  }
+
+  async ping(client: Pick<Client, "query">): Promise<{ ok: true }> {
+    await client.query("select 1");
+
+    return { ok: true };
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-filter-compiler.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-filter-compiler.service.ts
@@ -1,0 +1,64 @@
+import { parsePrimitive } from "../../shared/parse";
+import { UnsupportedDbReadError } from "../../readbackend/types";
+
+export interface DbFilterClause {
+  field: string;
+  operator: string;
+  value: unknown;
+}
+
+const FILTER_CLAUSE_PATTERN = /^([^[\]:]+)(?:\[([^[\]]+)\])?:(.*)$/;
+
+export class DbFilterCompilerService {
+  compile(filter?: string): DbFilterClause[] {
+    if (!filter) {
+      return [];
+    }
+
+    return filter
+      .split(";")
+      .map((clause) => clause.trim())
+      .filter(Boolean)
+      .map((clause) => parseClause(clause));
+  }
+}
+
+function parseClause(clause: string): DbFilterClause {
+  const match = FILTER_CLAUSE_PATTERN.exec(clause);
+
+  if (!match) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support filter clause ${JSON.stringify(clause)}.`,
+    );
+  }
+
+  const [, field, operator = "eq", rawValue] = match;
+
+  if (field.includes(".")) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support nested filter field ${JSON.stringify(field)}.`,
+    );
+  }
+
+  return {
+    field,
+    operator,
+    value: parseFilterValue(rawValue),
+  };
+}
+
+function parseFilterValue(rawValue: string): unknown {
+  const trimmed = rawValue.trim();
+
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+
+    if (!inner) {
+      return [];
+    }
+
+    return inner.split(",").map((item) => parsePrimitive(item.trim()));
+  }
+
+  return parsePrimitive(trimmed);
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-metadata-planner.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-metadata-planner.service.ts
@@ -1,0 +1,186 @@
+import {
+  type FieldMetadata,
+  type MetadataService,
+  type ObjectMetadata,
+} from "../../metadata/services/metadata.service";
+import { UnsupportedDbReadError } from "../../readbackend/types";
+
+type MetadataClient = Pick<MetadataService, "listObjects" | "getObject">;
+
+export interface DbRelationPlan {
+  relationName: string;
+  joinColumnName: string;
+  fieldMetadata: FieldMetadata;
+  objectMetadata: ObjectMetadata;
+  tableName: string;
+}
+
+export interface DbObjectPlan {
+  objectMetadata: ObjectMetadata;
+  tableName: string;
+  includes: DbRelationPlan[];
+}
+
+export class DbMetadataPlannerService {
+  constructor(private readonly metadataService: MetadataClient) {}
+
+  async planObject(objectName: string, options?: { include?: string }): Promise<DbObjectPlan> {
+    const objects = await this.metadataService.listObjects();
+    const baseObjectMetadata = findObjectMetadata(objects, objectName);
+    const includeRelations = parseIncludeList(options?.include);
+    const objectMetadata = await this.loadObjectMetadataForIncludes(
+      baseObjectMetadata,
+      includeRelations,
+    );
+
+    return {
+      objectMetadata,
+      tableName: toTableName(objectMetadata),
+      includes: includeRelations.map((relationName) =>
+        planRelationInclude(objects, objectMetadata, relationName),
+      ),
+    };
+  }
+
+  private async loadObjectMetadataForIncludes(
+    objectMetadata: ObjectMetadata,
+    includeRelations: string[],
+  ): Promise<ObjectMetadata> {
+    if (includeRelations.length === 0) {
+      return objectMetadata;
+    }
+
+    return this.metadataService.getObject(objectMetadata.id);
+  }
+}
+
+function findObjectMetadata(objects: ObjectMetadata[], objectName: string): ObjectMetadata {
+  const match = objects.find(
+    (objectMetadata) =>
+      objectMetadata.nameSingular === objectName || objectMetadata.namePlural === objectName,
+  );
+
+  if (!match) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support unknown object ${JSON.stringify(objectName)}.`,
+    );
+  }
+
+  return match;
+}
+
+function planRelationInclude(
+  objects: ObjectMetadata[],
+  objectMetadata: ObjectMetadata,
+  relationName: string,
+): DbRelationPlan {
+  const fieldMetadata = (objectMetadata.fields ?? []).find(
+    (field) => getFieldName(field) === relationName,
+  );
+
+  if (!fieldMetadata) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support include relation ${JSON.stringify(relationName)} for ${JSON.stringify(objectMetadata.namePlural ?? objectMetadata.nameSingular ?? objectMetadata.id)}.`,
+    );
+  }
+
+  const targetObjectMetadataId = getTargetObjectMetadataId(fieldMetadata);
+  const joinColumnName = getSupportedJoinColumnName(fieldMetadata, relationName);
+
+  if (!targetObjectMetadataId) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support non-relation include ${JSON.stringify(relationName)}.`,
+    );
+  }
+
+  const relatedObjectMetadata = objects.find(
+    (candidate) => candidate.id === targetObjectMetadataId,
+  );
+
+  if (!relatedObjectMetadata) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support include relation ${JSON.stringify(relationName)} with missing target metadata.`,
+    );
+  }
+
+  return {
+    relationName,
+    joinColumnName,
+    fieldMetadata,
+    objectMetadata: relatedObjectMetadata,
+    tableName: toTableName(relatedObjectMetadata),
+  };
+}
+
+function parseIncludeList(include?: string): string[] {
+  if (!include) {
+    return [];
+  }
+
+  return include
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function getFieldName(fieldMetadata: FieldMetadata): string | undefined {
+  const name = (fieldMetadata as Record<string, unknown>).name;
+
+  return typeof name === "string" ? name : undefined;
+}
+
+function getTargetObjectMetadataId(fieldMetadata: FieldMetadata): string | undefined {
+  const record = fieldMetadata as Record<string, unknown>;
+  const relationTargetObjectMetadataId = record.relationTargetObjectMetadataId;
+
+  if (typeof relationTargetObjectMetadataId === "string") {
+    return relationTargetObjectMetadataId;
+  }
+
+  const targetObjectMetadataId = record.targetObjectMetadataId;
+
+  return typeof targetObjectMetadataId === "string" ? targetObjectMetadataId : undefined;
+}
+
+function getSupportedJoinColumnName(fieldMetadata: FieldMetadata, relationName: string): string {
+  const settings = getRelationSettings(fieldMetadata);
+
+  if (settings.relationType !== "MANY_TO_ONE") {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support include relation ${JSON.stringify(relationName)} without a source-side MANY_TO_ONE join column.`,
+    );
+  }
+
+  if (typeof settings.joinColumnName !== "string" || settings.joinColumnName.trim().length === 0) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support include relation ${JSON.stringify(relationName)} without a source-side join column name.`,
+    );
+  }
+
+  return settings.joinColumnName;
+}
+
+function getRelationSettings(fieldMetadata: FieldMetadata): Record<string, unknown> {
+  const settings = (fieldMetadata as Record<string, unknown>).settings;
+
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+    return {};
+  }
+
+  return settings as Record<string, unknown>;
+}
+
+function toTableName(objectMetadata: ObjectMetadata): string {
+  const source = objectMetadata.nameSingular;
+
+  if (!source) {
+    throw new UnsupportedDbReadError(
+      `DB reads do not support object metadata without a name for ${JSON.stringify(objectMetadata.id)}.`,
+    );
+  }
+
+  return source
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[-\s]+/g, "_")
+    .toLowerCase();
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-profile.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-profile.service.ts
@@ -4,7 +4,7 @@ import { ConfigService, type DbProfileConfig } from "../../config/services/confi
 export interface DbProfileInitInput {
   workspace?: string;
   name: string;
-  proxyUrl: string;
+  databaseUrl: string;
   notes?: string;
   workspaceId?: string;
   cachedUser?: string;
@@ -28,7 +28,7 @@ export class DbProfileService {
     const profile: DbProfileConfig = {
       name: input.name,
       workspace,
-      proxyUrl: input.proxyUrl,
+      databaseUrl: input.databaseUrl,
       credentialSource: "manual",
       notes: input.notes,
       workspaceId: input.workspaceId,

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-profile.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-profile.service.ts
@@ -1,0 +1,114 @@
+import { CliError } from "../../errors/cli-error";
+import { ConfigService, type DbProfileConfig } from "../../config/services/config.service";
+
+export interface DbProfileInitInput {
+  workspace?: string;
+  name: string;
+  proxyUrl: string;
+  notes?: string;
+  workspaceId?: string;
+  cachedUser?: string;
+  cachedPassword?: string;
+}
+
+export class DbProfileService {
+  constructor(private readonly configService: ConfigService) {}
+
+  async resolveWorkspace(workspace?: string): Promise<string> {
+    const resolved = await this.configService.resolveApiConfig({
+      workspace,
+      requireAuth: false,
+    });
+
+    return resolved.workspace ?? workspace ?? "default";
+  }
+
+  async initProfile(input: DbProfileInitInput): Promise<DbProfileConfig> {
+    const workspace = await this.resolveWorkspace(input.workspace);
+    const profile: DbProfileConfig = {
+      name: input.name,
+      workspace,
+      proxyUrl: input.proxyUrl,
+      credentialSource: "manual",
+      notes: input.notes,
+      workspaceId: input.workspaceId,
+      cachedUser: input.cachedUser,
+      cachedPassword: input.cachedPassword,
+    };
+
+    await this.configService.saveDbProfile(workspace, profile);
+
+    return profile;
+  }
+
+  async saveProfile(workspace: string | undefined, profile: DbProfileConfig): Promise<void> {
+    await this.configService.saveDbProfile(await this.resolveWorkspace(workspace), profile);
+  }
+
+  async setActiveProfile(workspace: string | undefined, name: string): Promise<DbProfileConfig> {
+    const resolvedWorkspace = await this.resolveWorkspace(workspace);
+    await this.configService.setActiveDbProfile(resolvedWorkspace, name);
+
+    return this.getProfile(resolvedWorkspace, name);
+  }
+
+  async getProfile(workspace: string | undefined, name: string): Promise<DbProfileConfig> {
+    return this.configService.getDbProfile(await this.resolveWorkspace(workspace), name);
+  }
+
+  async getActiveProfile(workspace: string | undefined): Promise<DbProfileConfig | undefined> {
+    const resolvedWorkspace = await this.resolveWorkspace(workspace);
+
+    try {
+      return await this.configService.getActiveDbProfile(resolvedWorkspace);
+    } catch (error) {
+      if (this.isMissingWorkspace(error, resolvedWorkspace)) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  }
+
+  async listProfiles(workspace: string | undefined): Promise<DbProfileConfig[]> {
+    return this.configService.listDbProfiles(await this.resolveWorkspace(workspace));
+  }
+
+  async removeProfile(workspace: string | undefined, name: string): Promise<void> {
+    await this.configService.removeDbProfile(await this.resolveWorkspace(workspace), name);
+  }
+
+  async refreshCreds(workspace: string | undefined, name: string): Promise<DbProfileConfig> {
+    const resolvedWorkspace = await this.resolveWorkspace(workspace);
+    const profile = await this.getProfile(resolvedWorkspace, name);
+    const refreshed = {
+      ...profile,
+      lastRefreshedAt: new Date().toISOString(),
+    };
+
+    await this.configService.saveDbProfile(resolvedWorkspace, refreshed);
+
+    return refreshed;
+  }
+
+  async test(workspace: string | undefined, name: string): Promise<DbProfileConfig> {
+    const resolvedWorkspace = await this.resolveWorkspace(workspace);
+    const profile = await this.getProfile(resolvedWorkspace, name);
+    const validated = {
+      ...profile,
+      lastValidatedAt: new Date().toISOString(),
+    };
+
+    await this.configService.saveDbProfile(resolvedWorkspace, validated);
+
+    return validated;
+  }
+
+  private isMissingWorkspace(error: unknown, workspace: string): boolean {
+    return (
+      error instanceof CliError &&
+      error.code === "INVALID_ARGUMENTS" &&
+      error.message === `Workspace '${workspace}' does not exist`
+    );
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-records-read.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-records-read.service.ts
@@ -1,0 +1,704 @@
+import type { Client } from "pg";
+import type { MetadataService } from "../../metadata/services/metadata.service";
+import { DbConnectionError, UnsupportedDbReadError } from "../../readbackend/types";
+import type {
+  GetOptions,
+  GroupByParams,
+  ListOptions,
+  ListResponse,
+} from "../../records/services/api-records-read.service";
+import type { ResolvedDbConfig } from "./db-config-resolver.service";
+import { DbConnectionService } from "./db-connection.service";
+import type { DbFilterClause } from "./db-filter-compiler.service";
+import { DbFilterCompilerService } from "./db-filter-compiler.service";
+import type { DbRelationPlan } from "./db-metadata-planner.service";
+import { DbMetadataPlannerService } from "./db-metadata-planner.service";
+
+type MetadataClient = Pick<MetadataService, "listObjects" | "getObject">;
+type MetadataPlanner = Pick<DbMetadataPlannerService, "planObject">;
+type FilterCompiler = Pick<DbFilterCompilerService, "compile">;
+type DbConnector = Pick<DbConnectionService, "connect">;
+
+interface DbCountRow {
+  totalCount: number | string;
+}
+
+interface DbRecordRow {
+  rowData: unknown;
+}
+
+interface DbGroupByRow extends Record<string, unknown> {
+  countNotEmptyId?: number | string;
+}
+
+interface SupportedDbGroupByRequest {
+  fields: string[];
+  aggregateField?: "countNotEmptyId";
+  filter?: string;
+  limit: number;
+}
+
+const DEFAULT_LIST_LIMIT = 20;
+const DEFAULT_GROUP_BY_LIMIT = 50;
+const DB_CURSOR_PATTERN = /^db:(\d+)$/;
+const SIMPLE_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export class DbRecordsReadService {
+  private readonly metadataPlanner: MetadataPlanner;
+  private readonly filterCompiler: FilterCompiler;
+  private readonly dbConnectionService: DbConnector;
+
+  constructor(
+    metadataService: MetadataClient,
+    metadataPlanner?: MetadataPlanner,
+    filterCompiler?: FilterCompiler,
+    dbConnectionService?: DbConnector,
+  ) {
+    this.metadataPlanner =
+      metadataPlanner ?? new DbMetadataPlannerService(metadataService as MetadataService);
+    this.filterCompiler = filterCompiler ?? new DbFilterCompilerService();
+    this.dbConnectionService = dbConnectionService ?? new DbConnectionService();
+  }
+
+  async list(
+    target: ResolvedDbConfig,
+    object: string,
+    options: ListOptions = {},
+  ): Promise<ListResponse> {
+    assertSupportedListOptions(options);
+
+    const connectionOptions = resolveConnectionOptions(target);
+    const plan = await this.metadataPlanner.planObject(object, { include: options.include });
+    const clauses = this.filterCompiler.compile(options.filter);
+    const limit = resolveLimit(options.limit);
+    const offset = resolveOffset(options.cursor);
+    const client = await this.connectClient(connectionOptions, "list");
+
+    try {
+      const totalCount = await this.queryTotalCount(client, plan.tableName, clauses);
+      const data = await this.queryRows(client, plan.tableName, clauses, {
+        limit,
+        offset,
+        sort: options.sort,
+        order: options.order,
+      });
+      const lastOffset = offset + data.length - 1;
+
+      return {
+        data,
+        totalCount,
+        pageInfo: {
+          hasNextPage: offset + data.length < totalCount,
+          endCursor: data.length > 0 ? encodeCursor(lastOffset) : undefined,
+        },
+      };
+    } finally {
+      await client.end();
+    }
+  }
+
+  async listAll(
+    target: ResolvedDbConfig,
+    object: string,
+    options: ListOptions = {},
+  ): Promise<ListResponse> {
+    const all: unknown[] = [];
+    let cursor = options.cursor ?? "";
+    let totalCount: number | undefined;
+    let pageInfo: ListResponse["pageInfo"];
+
+    while (true) {
+      const response = await this.list(target, object, { ...options, cursor });
+      all.push(...response.data);
+      totalCount = response.totalCount ?? totalCount;
+      pageInfo = response.pageInfo;
+
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) {
+        break;
+      }
+
+      cursor = pageInfo.endCursor;
+    }
+
+    return {
+      data: all,
+      totalCount,
+      pageInfo,
+    };
+  }
+
+  async get(
+    target: ResolvedDbConfig,
+    object: string,
+    id: string,
+    options?: GetOptions,
+  ): Promise<unknown> {
+    const connectionOptions = resolveConnectionOptions(target);
+    const plan = await this.metadataPlanner.planObject(object, { include: options?.include });
+    const client = await this.connectClient(connectionOptions, "get");
+
+    try {
+      const baseRecord = await this.queryRecordById(client, plan.tableName, id);
+
+      if (!baseRecord || plan.includes.length === 0) {
+        return baseRecord;
+      }
+
+      return this.hydrateIncludes(client, baseRecord, plan.includes);
+    } finally {
+      await client.end();
+    }
+  }
+
+  async groupBy(
+    target: ResolvedDbConfig,
+    object: string,
+    payload?: unknown,
+    params?: GroupByParams,
+  ): Promise<unknown> {
+    const request = parseSupportedGroupByRequest(payload, params);
+    const connectionOptions = resolveConnectionOptions(target);
+    const plan = await this.metadataPlanner.planObject(object);
+    const clauses = this.filterCompiler.compile(request.filter);
+    const client = await this.connectClient(connectionOptions, "groupBy");
+
+    try {
+      return await this.queryGroupByRows(client, plan.tableName, request, clauses);
+    } finally {
+      await client.end();
+    }
+  }
+
+  private async queryTotalCount(
+    client: Pick<Client, "query">,
+    tableName: string,
+    clauses: DbFilterClause[],
+  ): Promise<number> {
+    const { sql, params } = buildWhereClause(clauses);
+    const result = await client.query<DbCountRow>(
+      `
+        select count(*)::text as "totalCount"
+        from ${quoteIdentifier(tableName)} as t
+        ${sql}
+      `,
+      params,
+    );
+
+    return toNumber(result.rows[0]?.totalCount);
+  }
+
+  private async queryRows(
+    client: Pick<Client, "query">,
+    tableName: string,
+    clauses: DbFilterClause[],
+    options: {
+      limit: number;
+      offset: number;
+      sort?: string;
+      order?: string;
+    },
+  ): Promise<unknown[]> {
+    const { sql: whereSql, params } = buildWhereClause(clauses);
+    const orderBy = buildOrderByClause(options.sort, options.order);
+    const result = await client.query<DbRecordRow>(
+      `
+        select to_jsonb(t) as "rowData"
+        from ${quoteIdentifier(tableName)} as t
+        ${whereSql}
+        ${orderBy}
+        limit $${params.length + 1}
+        offset $${params.length + 2}
+      `,
+      [...params, options.limit, options.offset],
+    );
+
+    return result.rows.map((row) => row.rowData);
+  }
+
+  private async queryRecordById(
+    client: Pick<Client, "query">,
+    tableName: string,
+    id: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    const result = await client.query<DbRecordRow>(
+      `
+        select to_jsonb(t) as "rowData"
+        from ${quoteIdentifier(tableName)} as t
+        where t."id" = $1
+        limit 1
+      `,
+      [id],
+    );
+
+    return asRecord(result.rows[0]?.rowData);
+  }
+
+  private async queryGroupByRows(
+    client: Pick<Client, "query">,
+    tableName: string,
+    request: SupportedDbGroupByRequest,
+    clauses: DbFilterClause[],
+  ): Promise<Array<Record<string, unknown>>> {
+    const { sql: whereSql, params } = buildWhereClause(clauses);
+    const fields = request.fields.map((field) => quoteColumn(field));
+    const selectSql = fields
+      .map((field, index) => `${field} as ${quoteIdentifier(getGroupByAlias(index))}`)
+      .join(", ");
+    const aggregateSql = request.aggregateField
+      ? `, count(*)::text as "${request.aggregateField}"`
+      : "";
+    const groupBySql = fields.join(", ");
+    const orderBySql = fields.map((field) => `${field} asc nulls first`).join(", ");
+    const result = await client.query<DbGroupByRow>(
+      `
+        select ${selectSql}${aggregateSql}
+        from ${quoteIdentifier(tableName)} as t
+        ${whereSql}
+        group by ${groupBySql}
+        order by ${orderBySql}
+        limit $${params.length + 1}
+      `,
+      [...params, request.limit],
+    );
+
+    return result.rows.map((row) => {
+      const group: Record<string, unknown> = {
+        groupByDimensionValues: request.fields.map((_, index) => row[getGroupByAlias(index)]),
+      };
+
+      if (request.aggregateField) {
+        group[request.aggregateField] = row[request.aggregateField] ?? null;
+      }
+
+      return group;
+    });
+  }
+
+  private async hydrateIncludes(
+    client: Pick<Client, "query">,
+    baseRecord: Record<string, unknown>,
+    includes: DbRelationPlan[],
+  ): Promise<Record<string, unknown>> {
+    const hydratedRecord = { ...baseRecord };
+
+    for (const relationPlan of includes) {
+      const relationIdFieldName = relationPlan.joinColumnName;
+
+      if (!hasOwn(hydratedRecord, relationIdFieldName)) {
+        throw new UnsupportedDbReadError(
+          `DB get does not support include hydration for relation ${JSON.stringify(relationPlan.relationName)} because ${JSON.stringify(relationIdFieldName)} is not present on the base row.`,
+        );
+      }
+
+      const relationId = hydratedRecord[relationIdFieldName];
+
+      if (typeof relationId !== "string" || relationId.length === 0) {
+        hydratedRecord[relationPlan.relationName] = null;
+        continue;
+      }
+
+      const relatedRecord = await this.queryRecordById(client, relationPlan.tableName, relationId);
+
+      hydratedRecord[relationPlan.relationName] = relatedRecord ?? null;
+    }
+
+    return hydratedRecord;
+  }
+
+  private async connectClient(
+    connectionOptions: ReturnType<typeof resolveConnectionOptions>,
+    operation: "list" | "get" | "groupBy",
+  ) {
+    try {
+      return await this.dbConnectionService.connect(connectionOptions);
+    } catch (error) {
+      throw new DbConnectionError(resolveRecordsOperationUnavailableMessage(operation), {
+        cause: error,
+      });
+    }
+  }
+}
+
+function assertSupportedListOptions(options: ListOptions): void {
+  if (options.include) {
+    throw new UnsupportedDbReadError("DB list does not support include hydration yet.");
+  }
+
+  if (options.params && Object.keys(options.params).length > 0) {
+    throw new UnsupportedDbReadError("DB list does not support custom query params.");
+  }
+}
+
+function resolveConnectionOptions(target: ResolvedDbConfig) {
+  if (!target.databaseUrl) {
+    throw new UnsupportedDbReadError("DB records read requires a resolved database URL.");
+  }
+
+  return {
+    databaseUrl: target.databaseUrl,
+  };
+}
+
+function parseSupportedGroupByRequest(
+  payload?: unknown,
+  params?: GroupByParams,
+): SupportedDbGroupByRequest {
+  const payloadRecord = asRecord(payload);
+
+  if (!payloadRecord) {
+    throw new UnsupportedDbReadError("DB groupBy requires a payload with groupBy fields.");
+  }
+
+  assertSupportedGroupByPayloadKeys(payloadRecord);
+  assertSupportedGroupByParamsKeys(params);
+
+  const fields = parseGroupByFields(payloadRecord.groupBy);
+  const payloadFilter = parseGroupByPayloadFilter(payloadRecord.filter);
+  const paramsFilter = parseSingleStringParam(params, "filter");
+
+  if (payloadFilter && paramsFilter) {
+    throw new UnsupportedDbReadError("DB groupBy does not support both payload and param filters.");
+  }
+
+  return {
+    fields,
+    aggregateField: parseGroupByAggregate(params),
+    filter: payloadFilter ?? paramsFilter,
+    limit: parseGroupByLimit(params),
+  };
+}
+
+function assertSupportedGroupByPayloadKeys(payload: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (key === "groupBy" || key === "filter") {
+      continue;
+    }
+
+    throw new UnsupportedDbReadError(
+      `DB groupBy does not support payload key ${JSON.stringify(key)}.`,
+    );
+  }
+}
+
+function assertSupportedGroupByParamsKeys(params?: GroupByParams): void {
+  if (!params) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(params)) {
+    if (!Array.isArray(value) || value.length === 0) {
+      continue;
+    }
+
+    if (key === "filter" || key === "limit" || key === "aggregate") {
+      continue;
+    }
+
+    throw new UnsupportedDbReadError(`DB groupBy does not support param ${JSON.stringify(key)}.`);
+  }
+}
+
+function parseGroupByFields(groupBy: unknown): string[] {
+  if (!Array.isArray(groupBy) || groupBy.length === 0) {
+    throw new UnsupportedDbReadError("DB groupBy requires a non-empty groupBy array.");
+  }
+
+  return groupBy.map((entry) => parseGroupByFieldEntry(entry));
+}
+
+function parseGroupByFieldEntry(entry: unknown): string {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new UnsupportedDbReadError("DB groupBy only supports simple field entries.");
+  }
+
+  const fields = Object.entries(entry as Record<string, unknown>).filter(
+    ([, value]) => value !== undefined,
+  );
+
+  if (fields.length !== 1) {
+    throw new UnsupportedDbReadError("DB groupBy only supports one field per groupBy entry.");
+  }
+
+  const [fieldName, enabled] = fields[0];
+
+  if (enabled !== true) {
+    throw new UnsupportedDbReadError(
+      `DB groupBy does not support advanced field definition for ${JSON.stringify(fieldName)}.`,
+    );
+  }
+
+  return fieldName;
+}
+
+function parseGroupByPayloadFilter(filter: unknown): string | undefined {
+  if (filter === undefined) {
+    return undefined;
+  }
+
+  if (typeof filter !== "string") {
+    throw new UnsupportedDbReadError("DB groupBy only supports string filters.");
+  }
+
+  return filter;
+}
+
+function parseGroupByAggregate(params?: GroupByParams): "countNotEmptyId" | undefined {
+  const aggregate = parseSingleStringParam(params, "aggregate");
+
+  if (aggregate === undefined) {
+    return undefined;
+  }
+
+  const normalizedFields = normalizeAggregateFields(aggregate);
+
+  if (normalizedFields.length !== 1 || normalizedFields[0] !== "countNotEmptyId") {
+    throw new UnsupportedDbReadError(
+      `DB groupBy only supports aggregate ${JSON.stringify("countNotEmptyId")}.`,
+    );
+  }
+
+  return "countNotEmptyId";
+}
+
+function parseGroupByLimit(params?: GroupByParams): number {
+  const rawLimit = parseSingleStringParam(params, "limit");
+
+  if (rawLimit === undefined) {
+    return DEFAULT_GROUP_BY_LIMIT;
+  }
+
+  if (!/^\d+$/.test(rawLimit)) {
+    throw new UnsupportedDbReadError(
+      `DB groupBy does not support limit ${JSON.stringify(rawLimit)}.`,
+    );
+  }
+
+  const limit = Number(rawLimit);
+
+  if (!Number.isFinite(limit) || limit < 1) {
+    throw new UnsupportedDbReadError(
+      `DB groupBy does not support limit ${JSON.stringify(rawLimit)}.`,
+    );
+  }
+
+  return Math.floor(limit);
+}
+
+function parseSingleStringParam(
+  params: GroupByParams | undefined,
+  key: string,
+): string | undefined {
+  const values = params?.[key];
+
+  if (!values || values.length === 0) {
+    return undefined;
+  }
+
+  if (values.length !== 1) {
+    throw new UnsupportedDbReadError(
+      `DB groupBy does not support multiple values for ${JSON.stringify(key)}.`,
+    );
+  }
+
+  return values[0];
+}
+
+function normalizeAggregateFields(raw: string): string[] {
+  const trimmed = raw.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed === "totalCount") {
+    return ["countNotEmptyId"];
+  }
+
+  if (!trimmed.startsWith("[")) {
+    return [trimmed];
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new UnsupportedDbReadError(
+      `DB groupBy could not parse aggregate ${JSON.stringify(raw)} as a JSON string array.`,
+    );
+  }
+
+  if (!Array.isArray(parsed) || parsed.some((entry) => typeof entry !== "string")) {
+    throw new UnsupportedDbReadError(
+      `DB groupBy could not parse aggregate ${JSON.stringify(raw)} as a JSON string array.`,
+    );
+  }
+
+  return parsed.map((entry) => (entry === "totalCount" ? "countNotEmptyId" : entry));
+}
+
+function resolveLimit(limit?: number): number {
+  if (!Number.isFinite(limit) || !limit || limit < 1) {
+    return DEFAULT_LIST_LIMIT;
+  }
+
+  return Math.floor(limit);
+}
+
+function resolveOffset(cursor?: string): number {
+  if (!cursor) {
+    return 0;
+  }
+
+  const match = DB_CURSOR_PATTERN.exec(cursor);
+
+  if (!match) {
+    throw new UnsupportedDbReadError(`DB list does not support cursor ${JSON.stringify(cursor)}.`);
+  }
+
+  return Number(match[1]) + 1;
+}
+
+function buildWhereClause(clauses: DbFilterClause[]): { sql: string; params: unknown[] } {
+  if (clauses.length === 0) {
+    return { sql: "", params: [] };
+  }
+
+  const params: unknown[] = [];
+  const fragments = clauses.map((clause) => compileFilterClause(clause, params));
+
+  return {
+    sql: `where ${fragments.join(" and ")}`,
+    params,
+  };
+}
+
+function compileFilterClause(clause: DbFilterClause, params: unknown[]): string {
+  const field = quoteColumn(clause.field);
+
+  switch (clause.operator) {
+    case "eq":
+      if (clause.value === null) {
+        return `${field} is null`;
+      }
+      params.push(clause.value);
+      return `${field} = $${params.length}`;
+    case "neq":
+      if (clause.value === null) {
+        return `${field} is not null`;
+      }
+      params.push(clause.value);
+      return `${field} <> $${params.length}`;
+    case "gt":
+      params.push(clause.value);
+      return `${field} > $${params.length}`;
+    case "gte":
+      params.push(clause.value);
+      return `${field} >= $${params.length}`;
+    case "lt":
+      params.push(clause.value);
+      return `${field} < $${params.length}`;
+    case "lte":
+      params.push(clause.value);
+      return `${field} <= $${params.length}`;
+    case "in":
+      if (!Array.isArray(clause.value)) {
+        throw new UnsupportedDbReadError(
+          `DB list requires array values for [in] filters on ${JSON.stringify(clause.field)}.`,
+        );
+      }
+      params.push(clause.value);
+      return `${field} = any($${params.length})`;
+    case "is":
+      if (clause.value === null || clause.value === "null") {
+        return `${field} is null`;
+      }
+      if (clause.value === "not_null") {
+        return `${field} is not null`;
+      }
+      throw new UnsupportedDbReadError(
+        `DB list does not support [is] value ${JSON.stringify(clause.value)}.`,
+      );
+    default:
+      throw new UnsupportedDbReadError(
+        `DB list does not support filter operator ${JSON.stringify(clause.operator)}.`,
+      );
+  }
+}
+
+function buildOrderByClause(sort?: string, order?: string): string {
+  const direction = order?.toLowerCase() === "desc" ? "desc" : "asc";
+  const nullsOrdering = direction === "desc" ? "nulls last" : "nulls first";
+
+  if (!sort) {
+    return `order by ${quoteColumn("id")} asc`;
+  }
+
+  const sortColumn = quoteColumn(sort);
+
+  if (sort === "id") {
+    return `order by ${sortColumn} ${direction} ${nullsOrdering}`;
+  }
+
+  return `order by ${sortColumn} ${direction} ${nullsOrdering}, ${quoteColumn("id")} asc`;
+}
+
+function quoteColumn(column: string): string {
+  if (!SIMPLE_IDENTIFIER_PATTERN.test(column)) {
+    throw new UnsupportedDbReadError(`DB list does not support field ${JSON.stringify(column)}.`);
+  }
+
+  return `t.${quoteIdentifier(column)}`;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function encodeCursor(offset: number): string {
+  return `db:${offset}`;
+}
+
+function getGroupByAlias(index: number): string {
+  return `group_${index}`;
+}
+
+function resolveRecordsOperationUnavailableMessage(operation: "list" | "get" | "groupBy"): string {
+  switch (operation) {
+    case "get":
+      return "DB records get is unavailable.";
+    case "groupBy":
+      return "DB records groupBy is unavailable.";
+    case "list":
+    default:
+      return "DB records list is unavailable.";
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function toNumber(value: number | string | undefined): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+
+  return 0;
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-search.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-search.service.ts
@@ -1,0 +1,364 @@
+import type { Client } from "pg";
+import type { ObjectMetadata, MetadataService } from "../../metadata/services/metadata.service";
+import { DbConnectionError, UnsupportedDbReadError } from "../../readbackend/types";
+import type {
+  SearchOptions,
+  SearchResponse,
+  SearchResult,
+} from "../../search/services/api-search.service";
+import type { ResolvedDbConfig } from "./db-config-resolver.service";
+import { DbConnectionService } from "./db-connection.service";
+import { DbMetadataPlannerService } from "./db-metadata-planner.service";
+
+type MetadataClient = Pick<MetadataService, "listObjects">;
+type MetadataPlanner = Pick<DbMetadataPlannerService, "planObject">;
+type DbConnector = Pick<DbConnectionService, "connect">;
+
+interface DbSearchRow {
+  recordId: string;
+  rowData: unknown;
+  tsRankCD: number | string;
+  tsRank: number | string;
+}
+
+export class DbSearchService {
+  private readonly metadataPlanner: MetadataPlanner;
+  private readonly dbConnectionService: DbConnector;
+
+  constructor(
+    private readonly metadataService: MetadataClient,
+    metadataPlanner?: MetadataPlanner,
+    dbConnectionService?: DbConnector,
+  ) {
+    this.metadataPlanner =
+      metadataPlanner ?? new DbMetadataPlannerService(metadataService as MetadataService);
+    this.dbConnectionService = dbConnectionService ?? new DbConnectionService();
+  }
+
+  async search(target: ResolvedDbConfig, options: SearchOptions): Promise<SearchResponse> {
+    if (options.filter) {
+      throw new UnsupportedDbReadError("DB search does not support filters.");
+    }
+
+    const query = options.query.trim();
+
+    if (!query) {
+      return emptySearchResponse();
+    }
+
+    const connectionOptions = resolveConnectionOptions(target);
+    const startOffset = resolveStartOffset(options.after);
+    const objectNames = await this.resolveSearchObjects(options);
+    const limit = options.limit ?? 20;
+    const fetchLimit = startOffset + limit + 1;
+
+    if (objectNames.length === 0) {
+      return emptySearchResponse();
+    }
+
+    const client = await this.connectClient(connectionOptions);
+
+    try {
+      const resultEntries: Array<{ result: SearchResult; index: number }> = [];
+      let index = 0;
+
+      for (const objectName of objectNames) {
+        try {
+          const plan = await this.metadataPlanner.planObject(objectName);
+          const rows = await this.queryObject(client, plan.tableName, query, fetchLimit);
+          const objectNameSingular = plan.objectMetadata.nameSingular ?? objectName;
+          const objectLabelSingular = getObjectLabel(plan.objectMetadata, objectNameSingular);
+
+          for (const row of rows) {
+            resultEntries.push({
+              index,
+              result: {
+                recordId: row.recordId,
+                objectNameSingular,
+                objectLabelSingular,
+                label: deriveLabel(row.rowData, row.recordId),
+                imageUrl: deriveImageUrl(row.rowData),
+                tsRankCD: toNumber(row.tsRankCD),
+                tsRank: toNumber(row.tsRank),
+              },
+            });
+            index += 1;
+          }
+        } catch (error) {
+          if (error instanceof UnsupportedDbReadError) {
+            continue;
+          }
+
+          throw error;
+        }
+      }
+
+      const sortedEntries = resultEntries.sort((left, right) => {
+        if (right.result.tsRankCD !== left.result.tsRankCD) {
+          return right.result.tsRankCD - left.result.tsRankCD;
+        }
+
+        if (right.result.tsRank !== left.result.tsRank) {
+          return right.result.tsRank - left.result.tsRank;
+        }
+
+        return left.index - right.index;
+      });
+      const pagedEntries = sortedEntries.slice(startOffset, startOffset + limit);
+      const data = pagedEntries.map((entry, pageIndex) => ({
+        ...entry.result,
+        cursor: encodeCursor(startOffset + pageIndex),
+      }));
+      const endCursor = data[data.length - 1]?.cursor;
+
+      return {
+        data,
+        pageInfo: {
+          hasNextPage: sortedEntries.length > startOffset + limit,
+          endCursor,
+        },
+      };
+    } finally {
+      await client.end();
+    }
+  }
+
+  private async resolveSearchObjects(options: SearchOptions): Promise<string[]> {
+    if (options.objects?.length) {
+      return applyExcludedObjects(options.objects, options.excludeObjects);
+    }
+
+    const objects = await this.metadataService.listObjects();
+    const names = objects
+      .map((objectMetadata) => objectMetadata.nameSingular)
+      .filter((value): value is string => typeof value === "string" && value.length > 0);
+
+    return applyExcludedObjects(names, options.excludeObjects);
+  }
+
+  private async queryObject(
+    client: Pick<Client, "query">,
+    tableName: string,
+    query: string,
+    limit: number,
+  ): Promise<DbSearchRow[]> {
+    const sql = `
+      with searchable_rows as (
+        select
+          t.id::text as "recordId",
+          jsonb_strip_nulls(to_jsonb(t)) as "rowData",
+          to_tsvector('simple', coalesce(jsonb_strip_nulls(to_jsonb(t))::text, '')) as document,
+          plainto_tsquery('simple', $1) as query
+        from ${quoteIdentifier(tableName)} as t
+      )
+      select
+        "recordId",
+        "rowData",
+        ts_rank_cd(document, query) as "tsRankCD",
+        ts_rank(document, query) as "tsRank"
+      from searchable_rows
+      where document @@ query
+      order by "tsRankCD" desc, "tsRank" desc, "recordId" asc
+      limit $2
+    `;
+    const result = await client.query(sql, [query, limit]);
+
+    return result.rows as DbSearchRow[];
+  }
+
+  private async connectClient(connectionOptions: ReturnType<typeof resolveConnectionOptions>) {
+    try {
+      return await this.dbConnectionService.connect(connectionOptions);
+    } catch (error) {
+      throw new DbConnectionError("DB search is unavailable.", { cause: error });
+    }
+  }
+}
+
+function resolveConnectionOptions(target: ResolvedDbConfig) {
+  const databaseUrl = target.databaseUrl;
+
+  if (!databaseUrl) {
+    throw new UnsupportedDbReadError("DB search requires a resolved database URL.");
+  }
+
+  return {
+    databaseUrl,
+  };
+}
+
+function applyExcludedObjects(objects: string[], excludeObjects?: string[]): string[] {
+  const excluded = new Set((excludeObjects ?? []).map((value) => value.toLowerCase()));
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  for (const objectName of objects) {
+    const normalized = objectName.toLowerCase();
+
+    if (excluded.has(normalized) || seen.has(normalized)) {
+      continue;
+    }
+
+    seen.add(normalized);
+    results.push(objectName);
+  }
+
+  return results;
+}
+
+function resolveStartOffset(after?: string): number {
+  if (!after) {
+    return 0;
+  }
+
+  const match = /^db:(\d+)$/.exec(after);
+
+  if (!match) {
+    throw new UnsupportedDbReadError(`DB search does not support cursor ${JSON.stringify(after)}.`);
+  }
+
+  return Number(match[1]) + 1;
+}
+
+function encodeCursor(offset: number): string {
+  return `db:${offset}`;
+}
+
+function emptySearchResponse(): SearchResponse {
+  return {
+    data: [],
+    pageInfo: {
+      hasNextPage: false,
+      endCursor: undefined,
+    },
+  };
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function getObjectLabel(objectMetadata: ObjectMetadata, fallback: string): string {
+  const labelSingular = objectMetadata.labelSingular;
+
+  if (typeof labelSingular === "string" && labelSingular.trim().length > 0) {
+    return labelSingular;
+  }
+
+  return fallback.charAt(0).toUpperCase() + fallback.slice(1);
+}
+
+function deriveLabel(rowData: unknown, fallback: string): string {
+  const record = asRecord(rowData);
+
+  if (!record) {
+    return fallback;
+  }
+
+  const directString = firstString(record, [
+    "label",
+    "displayName",
+    "fullName",
+    "title",
+    "subject",
+    "name",
+  ]);
+
+  if (directString) {
+    return directString;
+  }
+
+  const nestedName = deriveNameValue(record.name);
+
+  if (nestedName) {
+    return nestedName;
+  }
+
+  const rootName = joinNameParts(record);
+
+  if (rootName) {
+    return rootName;
+  }
+
+  const fallbackString = firstString(record, [
+    "email",
+    "primaryEmail",
+    "phone",
+    "linkedinLinkPrimary",
+    "domainName",
+  ]);
+
+  return fallbackString ?? fallback;
+}
+
+function deriveImageUrl(rowData: unknown): string | null {
+  const record = asRecord(rowData);
+
+  if (!record) {
+    return null;
+  }
+
+  return (
+    firstString(record, ["imageUrl", "avatarUrl", "pictureUrl", "photoUrl", "logoUrl"]) ?? null
+  );
+}
+
+function firstString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function deriveNameValue(value: unknown): string | undefined {
+  const record = asRecord(value);
+
+  if (!record) {
+    return undefined;
+  }
+
+  const directString = firstString(record, ["fullName", "displayName", "name"]);
+
+  if (directString) {
+    return directString;
+  }
+
+  return joinNameParts(record);
+}
+
+function joinNameParts(record: Record<string, unknown>): string | undefined {
+  const parts = ["firstName", "middleName", "lastName"]
+    .map((key) => record[key])
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  return parts.join(" ");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function toNumber(value: number | string | undefined): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.length > 0) {
+    return Number(value);
+  }
+
+  return 0;
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-status.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-status.service.ts
@@ -1,0 +1,54 @@
+import { CliError } from "../../errors/cli-error";
+import { DbProfileService } from "./db-profile.service";
+
+export interface DbStatusSummary {
+  workspace: string;
+  configured: boolean;
+  mode: "api" | "db";
+  profileName?: string;
+}
+
+export class DbStatusService {
+  constructor(private readonly dbProfiles: DbProfileService) {}
+
+  async getStatus(options?: { workspace?: string }): Promise<DbStatusSummary> {
+    const workspace = await this.dbProfiles.resolveWorkspace(options?.workspace);
+
+    try {
+      const profile = await this.dbProfiles.getActiveProfile(workspace);
+
+      if (!profile) {
+        return {
+          workspace,
+          configured: false,
+          mode: "api",
+        };
+      }
+
+      return {
+        workspace,
+        configured: true,
+        mode: "db",
+        profileName: profile.name,
+      };
+    } catch (error) {
+      if (this.isMissingWorkspace(error, workspace)) {
+        return {
+          workspace,
+          configured: false,
+          mode: "api",
+        };
+      }
+
+      throw error;
+    }
+  }
+
+  private isMissingWorkspace(error: unknown, workspace: string): boolean {
+    return (
+      error instanceof CliError &&
+      error.code === "INVALID_ARGUMENTS" &&
+      error.message === `Workspace '${workspace}' does not exist`
+    );
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/db/services/db-status.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/db/services/db-status.service.ts
@@ -1,54 +1,25 @@
-import { CliError } from "../../errors/cli-error";
-import { DbProfileService } from "./db-profile.service";
+import { DbConfigResolverService } from "./db-config-resolver.service";
 
 export interface DbStatusSummary {
   workspace: string;
   configured: boolean;
   mode: "api" | "db";
+  source: "env" | "profile" | "none" | "override";
   profileName?: string;
 }
 
 export class DbStatusService {
-  constructor(private readonly dbProfiles: DbProfileService) {}
+  constructor(private readonly dbConfigResolver: DbConfigResolverService) {}
 
   async getStatus(options?: { workspace?: string }): Promise<DbStatusSummary> {
-    const workspace = await this.dbProfiles.resolveWorkspace(options?.workspace);
+    const resolved = await this.dbConfigResolver.resolve(options);
 
-    try {
-      const profile = await this.dbProfiles.getActiveProfile(workspace);
-
-      if (!profile) {
-        return {
-          workspace,
-          configured: false,
-          mode: "api",
-        };
-      }
-
-      return {
-        workspace,
-        configured: true,
-        mode: "db",
-        profileName: profile.name,
-      };
-    } catch (error) {
-      if (this.isMissingWorkspace(error, workspace)) {
-        return {
-          workspace,
-          configured: false,
-          mode: "api",
-        };
-      }
-
-      throw error;
-    }
-  }
-
-  private isMissingWorkspace(error: unknown, workspace: string): boolean {
-    return (
-      error instanceof CliError &&
-      error.code === "INVALID_ARGUMENTS" &&
-      error.message === `Workspace '${workspace}' does not exist`
-    );
+    return {
+      workspace: resolved.workspace,
+      configured: resolved.mode === "db",
+      mode: resolved.mode,
+      source: resolved.source,
+      profileName: resolved.profileName,
+    };
   }
 }

--- a/packages/twenty-sdk/src/cli/utilities/readbackend/__tests__/read-backend.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/readbackend/__tests__/read-backend.service.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReadBackendService } from "../read-backend.service";
+import { DbConnectionError, UnsupportedDbReadError } from "../types";
+
+describe("ReadBackendService", () => {
+  it("uses API search when the resolved target is not db", async () => {
+    const apiSearch = {
+      search: vi.fn().mockResolvedValue({ data: [{ recordId: "api-1" }] }),
+    };
+    const resolver = {
+      resolve: vi.fn().mockResolvedValue({ mode: "api", source: "none", workspace: "ws" }),
+    };
+    const dbSearch = {
+      search: vi.fn(),
+    };
+
+    const service = new ReadBackendService(resolver as never, apiSearch as never, undefined, {
+      search: dbSearch as never,
+    });
+    const result = await service.runSearch({ query: "john" });
+
+    expect(resolver.resolve).toHaveBeenCalledWith({ workspace: undefined });
+    expect(apiSearch.search).toHaveBeenCalledWith({ query: "john" });
+    expect(dbSearch.search).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: [{ recordId: "api-1" }] });
+  });
+
+  it("uses DB search when the resolved target is db", async () => {
+    const target = {
+      mode: "db",
+      source: "env",
+      workspace: "ws",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
+    };
+    const apiSearch = {
+      search: vi.fn(),
+    };
+    const resolver = {
+      resolve: vi.fn().mockResolvedValue(target),
+    };
+    const dbSearch = {
+      search: vi.fn().mockResolvedValue({ data: [{ recordId: "db-1" }] }),
+    };
+
+    const service = new ReadBackendService(resolver as never, apiSearch as never, undefined, {
+      search: dbSearch as never,
+    });
+    const result = await service.runSearch({ query: "john" });
+
+    expect(dbSearch.search).toHaveBeenCalledWith(target, { query: "john" });
+    expect(apiSearch.search).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: [{ recordId: "db-1" }] });
+  });
+
+  it("falls back to API search when the DB read is unsupported", async () => {
+    const target = {
+      mode: "db",
+      source: "profile",
+      workspace: "ws",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
+      profileName: "readonly",
+    };
+    const apiSearch = {
+      search: vi.fn().mockResolvedValue({ data: [{ recordId: "api-1" }] }),
+    };
+    const resolver = {
+      resolve: vi.fn().mockResolvedValue(target),
+    };
+    const dbSearch = {
+      search: vi.fn().mockRejectedValue(new UnsupportedDbReadError("search not implemented")),
+    };
+
+    const service = new ReadBackendService(resolver as never, apiSearch as never, undefined, {
+      search: dbSearch as never,
+    });
+    const result = await service.runSearch({ query: "john" });
+
+    expect(dbSearch.search).toHaveBeenCalledWith(target, { query: "john" });
+    expect(apiSearch.search).toHaveBeenCalledWith({ query: "john" });
+    expect(result).toEqual({ data: [{ recordId: "api-1" }] });
+  });
+
+  it("falls back to API search when the DB connection fails", async () => {
+    const target = {
+      mode: "db",
+      source: "env",
+      workspace: "ws",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
+    };
+    const apiSearch = {
+      search: vi.fn().mockResolvedValue({ data: [{ recordId: "api-1" }] }),
+    };
+    const resolver = {
+      resolve: vi.fn().mockResolvedValue(target),
+    };
+    const dbSearch = {
+      search: vi.fn().mockRejectedValue(new DbConnectionError("database unavailable")),
+    };
+
+    const service = new ReadBackendService(resolver as never, apiSearch as never, undefined, {
+      search: dbSearch as never,
+    });
+    const result = await service.runSearch({ query: "john" });
+
+    expect(dbSearch.search).toHaveBeenCalledWith(target, { query: "john" });
+    expect(apiSearch.search).toHaveBeenCalledWith({ query: "john" });
+    expect(result).toEqual({ data: [{ recordId: "api-1" }] });
+  });
+
+  it("uses DB records reads when the resolved target is db", async () => {
+    const target = {
+      mode: "db",
+      source: "env",
+      workspace: "ws",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
+    };
+    const resolver = {
+      resolve: vi.fn().mockResolvedValue(target),
+    };
+    const apiSearch = {
+      search: vi.fn(),
+    };
+    const apiRecords = {
+      list: vi.fn(),
+      listAll: vi.fn(),
+      get: vi.fn(),
+      groupBy: vi.fn(),
+    };
+    const dbRecords = {
+      list: vi.fn().mockResolvedValue({ data: [{ id: "db-1" }] }),
+    };
+
+    const service = new ReadBackendService(
+      resolver as never,
+      apiSearch as never,
+      apiRecords as never,
+      { records: dbRecords as never },
+    );
+    const result = await service.list("people", { limit: 1 });
+
+    expect(dbRecords.list).toHaveBeenCalledWith(target, "people", { limit: 1 });
+    expect(apiRecords.list).not.toHaveBeenCalled();
+    expect(result).toEqual({ data: [{ id: "db-1" }] });
+  });
+
+  it("falls back to API records reads when the DB read is unsupported", async () => {
+    const target = {
+      mode: "db",
+      source: "profile",
+      workspace: "ws",
+      databaseUrl: "postgresql://db.example.com:5432/twenty",
+      profileName: "readonly",
+    };
+    const resolver = {
+      resolve: vi.fn().mockResolvedValue(target),
+    };
+    const apiSearch = {
+      search: vi.fn(),
+    };
+    const apiRecords = {
+      list: vi.fn().mockResolvedValue({ data: [{ id: "api-1" }] }),
+      listAll: vi.fn(),
+      get: vi.fn(),
+      groupBy: vi.fn(),
+    };
+    const dbRecords = {
+      list: vi.fn().mockRejectedValue(new UnsupportedDbReadError("unsupported include")),
+    };
+
+    const service = new ReadBackendService(
+      resolver as never,
+      apiSearch as never,
+      apiRecords as never,
+      { records: dbRecords as never },
+    );
+    const result = await service.list("people", { include: "company" });
+
+    expect(dbRecords.list).toHaveBeenCalledWith(target, "people", { include: "company" });
+    expect(apiRecords.list).toHaveBeenCalledWith("people", { include: "company" });
+    expect(result).toEqual({ data: [{ id: "api-1" }] });
+  });
+});

--- a/packages/twenty-sdk/src/cli/utilities/readbackend/read-backend.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/readbackend/read-backend.service.ts
@@ -1,0 +1,110 @@
+import type { ResolvedDbConfig } from "../db/services/db-config-resolver.service";
+import type { DbConfigResolverService } from "../db/services/db-config-resolver.service";
+import type { ApiRecordsReadService } from "../records/services/api-records-read.service";
+import type {
+  GetOptions,
+  GroupByParams,
+  ListOptions,
+  ListResponse,
+} from "../records/services/api-records-read.service";
+import type { ApiSearchService } from "../search/services/api-search.service";
+import type { SearchOptions, SearchResponse } from "../search/services/api-search.service";
+import {
+  DbConnectionError,
+  type ReadBackendDbReads,
+  type RecordsReadBackend,
+  type SearchReadBackend,
+  UnsupportedDbReadError,
+} from "./types";
+
+type DbConfigResolver = Pick<DbConfigResolverService, "resolve">;
+type ApiSearchReader = Pick<ApiSearchService, "search">;
+type ApiRecordsReader = Pick<ApiRecordsReadService, "list" | "listAll" | "get" | "groupBy">;
+
+interface ReadBackendServiceOptions {
+  workspace?: string;
+}
+
+export class ReadBackendService implements SearchReadBackend, RecordsReadBackend {
+  constructor(
+    private readonly dbConfigResolver: DbConfigResolver,
+    private readonly apiSearch: ApiSearchReader,
+    private readonly apiRecords?: ApiRecordsReader,
+    private readonly dbReads: ReadBackendDbReads = {},
+    private readonly options: ReadBackendServiceOptions = {},
+  ) {}
+
+  async runSearch(options: SearchOptions): Promise<SearchResponse> {
+    return this.runRead(
+      () => this.apiSearch.search(options),
+      this.dbReads.search ? (target) => this.dbReads.search!.search(target, options) : undefined,
+    );
+  }
+
+  async list(object: string, options: ListOptions = {}): Promise<ListResponse> {
+    return this.runRead(
+      () => this.requireApiRecords().list(object, options),
+      this.dbReads.records?.list
+        ? (target) => this.dbReads.records!.list!(target, object, options)
+        : undefined,
+    );
+  }
+
+  async listAll(object: string, options: ListOptions = {}): Promise<ListResponse> {
+    return this.runRead(
+      () => this.requireApiRecords().listAll(object, options),
+      this.dbReads.records?.listAll
+        ? (target) => this.dbReads.records!.listAll!(target, object, options)
+        : undefined,
+    );
+  }
+
+  async get(object: string, id: string, options?: GetOptions): Promise<unknown> {
+    return this.runRead(
+      () => this.requireApiRecords().get(object, id, options),
+      this.dbReads.records?.get
+        ? (target) => this.dbReads.records!.get!(target, object, id, options)
+        : undefined,
+    );
+  }
+
+  async groupBy(object: string, payload?: unknown, params?: GroupByParams): Promise<unknown> {
+    return this.runRead(
+      () => this.requireApiRecords().groupBy(object, payload, params),
+      this.dbReads.records?.groupBy
+        ? (target) => this.dbReads.records!.groupBy!(target, object, payload, params)
+        : undefined,
+    );
+  }
+
+  private async runRead<T>(
+    apiRead: () => Promise<T>,
+    dbRead?: (target: ResolvedDbConfig) => Promise<T>,
+  ): Promise<T> {
+    const target = await this.dbConfigResolver.resolve({
+      workspace: this.options.workspace,
+    });
+
+    if (target.mode !== "db" || !dbRead) {
+      return apiRead();
+    }
+
+    try {
+      return await dbRead(target);
+    } catch (error) {
+      if (error instanceof UnsupportedDbReadError || error instanceof DbConnectionError) {
+        return apiRead();
+      }
+
+      throw error;
+    }
+  }
+
+  private requireApiRecords(): ApiRecordsReader {
+    if (!this.apiRecords) {
+      throw new Error("ReadBackendService requires API records support for records reads.");
+    }
+
+    return this.apiRecords;
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/readbackend/types.ts
+++ b/packages/twenty-sdk/src/cli/utilities/readbackend/types.ts
@@ -1,0 +1,62 @@
+import type { ResolvedDbConfig } from "../db/services/db-config-resolver.service";
+import type {
+  GetOptions,
+  GroupByParams,
+  ListOptions,
+  ListResponse,
+} from "../records/services/api-records-read.service";
+import type { SearchOptions, SearchResponse } from "../search/services/api-search.service";
+
+export class UnsupportedDbReadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedDbReadError";
+  }
+}
+
+export class DbConnectionError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "DbConnectionError";
+
+    if (options?.cause !== undefined) {
+      Object.defineProperty(this, "cause", {
+        value: options.cause,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+  }
+}
+
+export interface SearchReadBackend {
+  runSearch(options: SearchOptions): Promise<SearchResponse>;
+}
+
+export interface DbSearchReadService {
+  search(target: ResolvedDbConfig, options: SearchOptions): Promise<SearchResponse>;
+}
+
+export interface RecordsReadBackend {
+  list(object: string, options?: ListOptions): Promise<ListResponse>;
+  listAll(object: string, options?: ListOptions): Promise<ListResponse>;
+  get(object: string, id: string, options?: GetOptions): Promise<unknown>;
+  groupBy(object: string, payload?: unknown, params?: GroupByParams): Promise<unknown>;
+}
+
+export interface DbRecordsReadService {
+  list(target: ResolvedDbConfig, object: string, options?: ListOptions): Promise<ListResponse>;
+  listAll(target: ResolvedDbConfig, object: string, options?: ListOptions): Promise<ListResponse>;
+  get(target: ResolvedDbConfig, object: string, id: string, options?: GetOptions): Promise<unknown>;
+  groupBy(
+    target: ResolvedDbConfig,
+    object: string,
+    payload?: unknown,
+    params?: GroupByParams,
+  ): Promise<unknown>;
+}
+
+export interface ReadBackendDbReads {
+  search?: DbSearchReadService;
+  records?: Partial<DbRecordsReadService>;
+}

--- a/packages/twenty-sdk/src/cli/utilities/records/services/__tests__/records.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/records/services/__tests__/records.service.spec.ts
@@ -2,6 +2,67 @@ import { describe, it, expect, vi } from "vitest";
 import { RecordsService } from "../records.service";
 
 describe("RecordsService", () => {
+  describe("read backend delegation", () => {
+    it("delegates read methods through the shared read backend when provided", async () => {
+      const mockApi = {
+        get: vi.fn(),
+        post: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+      };
+      const mockReadBackend = {
+        list: vi.fn().mockResolvedValue({ data: [{ id: "1" }] }),
+        listAll: vi.fn().mockResolvedValue({ data: [{ id: "1" }, { id: "2" }] }),
+        get: vi.fn().mockResolvedValue({ id: "1" }),
+        groupBy: vi.fn().mockResolvedValue({ groups: [{ key: "NYC" }] }),
+      };
+
+      const service = new RecordsService(mockApi as any, { readBackend: mockReadBackend as any });
+
+      await expect(service.list("people", { limit: 1 })).resolves.toEqual({ data: [{ id: "1" }] });
+      await expect(service.listAll("people")).resolves.toEqual({
+        data: [{ id: "1" }, { id: "2" }],
+      });
+      await expect(service.get("people", "1")).resolves.toEqual({ id: "1" });
+      await expect(service.groupBy("people", { groupBy: [{ city: true }] })).resolves.toEqual({
+        groups: [{ key: "NYC" }],
+      });
+
+      expect(mockReadBackend.list).toHaveBeenCalledWith("people", { limit: 1 });
+      expect(mockReadBackend.listAll).toHaveBeenCalledWith("people", {});
+      expect(mockReadBackend.get).toHaveBeenCalledWith("people", "1", undefined);
+      expect(mockReadBackend.groupBy).toHaveBeenCalledWith(
+        "people",
+        { groupBy: [{ city: true }] },
+        undefined,
+      );
+      expect(mockApi.get).not.toHaveBeenCalled();
+    });
+
+    it("keeps mutations on the API service even when a read backend is provided", async () => {
+      const mockApi = {
+        get: vi.fn(),
+        post: vi.fn().mockResolvedValue({
+          data: { data: { createPerson: { id: "1", name: "Alice" } } },
+        }),
+        patch: vi.fn(),
+        delete: vi.fn(),
+      };
+      const mockReadBackend = {
+        list: vi.fn(),
+        listAll: vi.fn(),
+        get: vi.fn(),
+        groupBy: vi.fn(),
+      };
+
+      const service = new RecordsService(mockApi as any, { readBackend: mockReadBackend as any });
+      const result = await service.create("people", { name: "Alice" });
+
+      expect(mockApi.post).toHaveBeenCalledWith("/rest/people", { name: "Alice" });
+      expect(result).toEqual({ id: "1", name: "Alice" });
+    });
+  });
+
   describe("list", () => {
     it("lists records with params", async () => {
       const mockApi = {

--- a/packages/twenty-sdk/src/cli/utilities/records/services/api-records-read.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/records/services/api-records-read.service.ts
@@ -1,0 +1,212 @@
+import { ApiService } from "../../api/services/api.service";
+import { singularize } from "../../shared/parse";
+
+type RecordsApiClient = Pick<ApiService, "get">;
+
+export interface ListOptions {
+  limit?: number;
+  cursor?: string;
+  filter?: string;
+  sort?: string;
+  order?: string;
+  include?: string;
+  params?: Record<string, string[]>;
+}
+
+export interface GetOptions {
+  include?: string;
+}
+
+export interface PageInfo {
+  hasNextPage?: boolean;
+  endCursor?: string;
+}
+
+export interface ListResponse {
+  data: unknown[];
+  totalCount?: number;
+  pageInfo?: PageInfo;
+}
+
+export type GroupByParams = Record<string, string[]>;
+
+export class ApiRecordsReadService {
+  constructor(private readonly api: RecordsApiClient) {}
+
+  async list(object: string, options: ListOptions = {}): Promise<ListResponse> {
+    const params: Record<string, string | string[]> = {};
+    if (options.limit) params.limit = String(options.limit);
+    if (options.cursor) params.starting_after = options.cursor;
+    if (options.sort) params.order_by = formatOrderBy(options.sort, options.order);
+    if (options.include) params.depth = "1";
+    if (options.filter) params.filter = options.filter;
+    if (options.params) {
+      for (const [key, values] of Object.entries(options.params)) {
+        params[key] = values.length === 1 ? values[0] : values;
+      }
+    }
+
+    const response = await this.api.get(`/rest/${object}`, { params });
+    const payload = response.data as any;
+    const dataSection = payload?.data ?? {};
+    const records = extractArray(dataSection, object);
+    return {
+      data: records,
+      totalCount: payload?.totalCount,
+      pageInfo: payload?.pageInfo,
+    };
+  }
+
+  async listAll(object: string, options: ListOptions = {}): Promise<ListResponse> {
+    const all: unknown[] = [];
+    let cursor = options.cursor ?? "";
+    let pageInfo: PageInfo | undefined;
+    let totalCount: number | undefined;
+
+    while (true) {
+      const response = await this.list(object, { ...options, cursor });
+      all.push(...response.data);
+      pageInfo = response.pageInfo;
+      totalCount = response.totalCount ?? totalCount;
+      if (!pageInfo?.hasNextPage || !pageInfo?.endCursor) {
+        break;
+      }
+      cursor = pageInfo.endCursor;
+    }
+
+    return { data: all, totalCount, pageInfo };
+  }
+
+  async get(object: string, id: string, options?: GetOptions): Promise<unknown> {
+    const params: Record<string, string> = {};
+    if (options?.include) {
+      params.depth = "1";
+    }
+    const response = await this.api.get(`/rest/${object}/${id}`, { params });
+    const payload = response.data as any;
+    const dataSection = payload?.data ?? {};
+    const singular = singularize(object);
+    return dataSection[singular] ?? dataSection[object] ?? firstValue(dataSection);
+  }
+
+  async groupBy(object: string, payload?: unknown, params?: GroupByParams): Promise<unknown> {
+    const path = `/rest/${object}/groupBy`;
+    const response = await this.api.get(path, {
+      params: {
+        ...flattenParams(params),
+        ...serializeGroupByPayload(payload),
+      },
+    });
+    return response.data ?? null;
+  }
+}
+
+function extractArray(dataSection: Record<string, unknown>, object: string): unknown[] {
+  const raw = dataSection?.[object];
+  if (Array.isArray(raw)) return raw;
+  for (const value of Object.values(dataSection)) {
+    if (Array.isArray(value)) return value as unknown[];
+  }
+  return [];
+}
+
+function firstValue(dataSection: Record<string, unknown>): unknown {
+  const values = Object.values(dataSection);
+  if (values.length === 0) return undefined;
+  return values[0];
+}
+
+function flattenParams(
+  params?: Record<string, string[]>,
+): Record<string, string | string[]> | undefined {
+  if (!params) return undefined;
+  const out: Record<string, string | string[]> = {};
+  for (const [key, values] of Object.entries(params)) {
+    out[key] = values.length === 1 ? values[0] : values;
+  }
+  return out;
+}
+
+function formatOrderBy(sort: string, order?: string): string {
+  const direction = order?.toLowerCase() === "desc" ? "DescNullsLast" : "AscNullsFirst";
+
+  return `${sort}[${direction}]`;
+}
+
+function serializeGroupByPayload(payload?: unknown): Record<string, string | string[]> {
+  if (Array.isArray(payload)) {
+    return {
+      group_by: JSON.stringify(payload),
+    };
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+
+  const serialized: Record<string, string | string[]> = {};
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (key === "groupBy" || key === "group_by") {
+      serialized.group_by = JSON.stringify(value);
+      continue;
+    }
+
+    if (key === "orderBy" || key === "order_by") {
+      serialized.order_by = JSON.stringify(value);
+      continue;
+    }
+
+    if (key === "viewId" || key === "view_id") {
+      serialized.view_id = String(value);
+      continue;
+    }
+
+    if (key === "includeRecordsSample" || key === "include_records_sample") {
+      serialized.include_records_sample = String(value);
+      continue;
+    }
+
+    if (key === "filter" && isRecord(value)) {
+      serialized.filter = serializeFilter(value);
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      serialized[key] = value.map(String);
+      continue;
+    }
+
+    serialized[key] = typeof value === "object" ? JSON.stringify(value) : String(value);
+  }
+
+  return serialized;
+}
+
+function serializeFilter(filter: Record<string, unknown>): string {
+  return Object.entries(filter)
+    .map(([field, condition]) => {
+      if (!isRecord(condition)) {
+        return `${field}[eq]:${String(condition)}`;
+      }
+
+      const clauses = Object.entries(condition).map(([operator, value]) => {
+        if (Array.isArray(value)) {
+          return `${field}[${operator}]:[${value.map(String).join(",")}]`;
+        }
+
+        return `${field}[${operator}]:${String(value)}`;
+      });
+
+      return clauses.join(";");
+    })
+    .join(";");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/twenty-sdk/src/cli/utilities/records/services/records.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/records/services/records.service.ts
@@ -1,90 +1,52 @@
 import { ApiService } from "../../api/services/api.service";
 import { CliError } from "../../errors/cli-error";
+import type { RecordsReadBackend } from "../../readbackend/types";
 import { capitalize, singularize } from "../../shared/parse";
+import {
+  ApiRecordsReadService,
+  type GetOptions,
+  type GroupByParams,
+  type ListOptions,
+  type ListResponse,
+} from "./api-records-read.service";
 
-export interface ListOptions {
-  limit?: number;
-  cursor?: string;
-  filter?: string;
-  sort?: string;
-  order?: string;
-  include?: string;
-  params?: Record<string, string[]>;
-}
-
-export interface PageInfo {
-  hasNextPage?: boolean;
-  endCursor?: string;
-}
-
-export interface ListResponse {
-  data: unknown[];
-  totalCount?: number;
-  pageInfo?: PageInfo;
-}
+export type {
+  GetOptions,
+  GroupByParams,
+  ListOptions,
+  ListResponse,
+  PageInfo,
+} from "./api-records-read.service";
 
 interface BulkMutationOptions {
   filter: string;
   include?: string;
 }
 
+interface RecordsServiceDependencies {
+  readBackend?: RecordsReadBackend;
+}
+
 export class RecordsService {
-  constructor(private api: ApiService) {}
+  private readonly readBackend: RecordsReadBackend;
+
+  constructor(
+    private readonly api: ApiService,
+    dependencies: RecordsServiceDependencies = {},
+  ) {
+    this.readBackend = dependencies.readBackend ?? new ApiRecordsReadService(api);
+  }
 
   async list(object: string, options: ListOptions = {}): Promise<ListResponse> {
-    const params: Record<string, string | string[]> = {};
-    if (options.limit) params.limit = String(options.limit);
-    if (options.cursor) params.starting_after = options.cursor;
-    if (options.sort) params.order_by = formatOrderBy(options.sort, options.order);
-    if (options.include) params.depth = "1";
-    if (options.filter) params.filter = options.filter;
-    if (options.params) {
-      for (const [key, values] of Object.entries(options.params)) {
-        params[key] = values.length === 1 ? values[0] : values;
-      }
-    }
-
-    const response = await this.api.get(`/rest/${object}`, { params });
-    const payload = response.data as any;
-    const dataSection = payload?.data ?? {};
-    const records = extractArray(dataSection, object);
-    return {
-      data: records,
-      totalCount: payload?.totalCount,
-      pageInfo: payload?.pageInfo,
-    };
+    return this.readBackend.list(object, options);
   }
 
   async listAll(object: string, options: ListOptions = {}): Promise<ListResponse> {
-    const all: unknown[] = [];
-    let cursor = options.cursor ?? "";
-    let pageInfo: PageInfo | undefined;
-    let totalCount: number | undefined;
-
-    while (true) {
-      const response = await this.list(object, { ...options, cursor });
-      all.push(...response.data);
-      pageInfo = response.pageInfo;
-      totalCount = response.totalCount ?? totalCount;
-      if (!pageInfo?.hasNextPage || !pageInfo?.endCursor) {
-        break;
-      }
-      cursor = pageInfo.endCursor;
-    }
-
-    return { data: all, totalCount, pageInfo };
+    return this.readBackend.listAll(object, options);
   }
 
-  async get(object: string, id: string, options?: { include?: string }): Promise<unknown> {
-    const params: Record<string, string> = {};
-    if (options?.include) {
-      params.depth = "1";
-    }
-    const response = await this.api.get(`/rest/${object}/${id}`, { params });
-    const payload = response.data as any;
-    const dataSection = payload?.data ?? {};
-    const singular = singularize(object);
-    return dataSection[singular] ?? dataSection[object] ?? firstValue(dataSection);
+  async get(object: string, id: string, options?: GetOptions): Promise<unknown> {
+    return this.readBackend.get(object, id, options);
   }
 
   async create(object: string, data: Record<string, unknown>): Promise<unknown> {
@@ -173,19 +135,8 @@ export class RecordsService {
     return response.data ?? null;
   }
 
-  async groupBy(
-    object: string,
-    payload?: unknown,
-    params?: Record<string, string[]>,
-  ): Promise<unknown> {
-    const path = `/rest/${object}/groupBy`;
-    const response = await this.api.get(path, {
-      params: {
-        ...flattenParams(params),
-        ...serializeGroupByPayload(payload),
-      },
-    });
-    return response.data ?? null;
+  async groupBy(object: string, payload?: unknown, params?: GroupByParams): Promise<unknown> {
+    return this.readBackend.groupBy(object, payload, params);
   }
 
   async findDuplicates(object: string, payload: unknown): Promise<unknown> {
@@ -199,36 +150,10 @@ export class RecordsService {
   }
 }
 
-function extractArray(dataSection: Record<string, unknown>, object: string): unknown[] {
-  const raw = dataSection?.[object];
-  if (Array.isArray(raw)) return raw;
-  for (const value of Object.values(dataSection)) {
-    if (Array.isArray(value)) return value as unknown[];
-  }
-  return [];
-}
-
 function firstValue(dataSection: Record<string, unknown>): unknown {
   const values = Object.values(dataSection);
   if (values.length === 0) return undefined;
   return values[0];
-}
-
-function flattenParams(
-  params?: Record<string, string[]>,
-): Record<string, string | string[]> | undefined {
-  if (!params) return undefined;
-  const out: Record<string, string | string[]> = {};
-  for (const [key, values] of Object.entries(params)) {
-    out[key] = values.length === 1 ? values[0] : values;
-  }
-  return out;
-}
-
-function formatOrderBy(sort: string, order?: string): string {
-  const direction = order?.toLowerCase() === "desc" ? "DescNullsLast" : "AscNullsFirst";
-
-  return `${sort}[${direction}]`;
 }
 
 function extractRecordId(record: Record<string, unknown>): string {
@@ -242,84 +167,6 @@ function extractRecordId(record: Record<string, unknown>): string {
   }
 
   return id;
-}
-
-function serializeGroupByPayload(payload?: unknown): Record<string, string | string[]> {
-  if (Array.isArray(payload)) {
-    return {
-      group_by: JSON.stringify(payload),
-    };
-  }
-
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    return {};
-  }
-
-  const serialized: Record<string, string | string[]> = {};
-
-  for (const [key, value] of Object.entries(payload)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    if (key === "groupBy" || key === "group_by") {
-      serialized.group_by = JSON.stringify(value);
-      continue;
-    }
-
-    if (key === "orderBy" || key === "order_by") {
-      serialized.order_by = JSON.stringify(value);
-      continue;
-    }
-
-    if (key === "viewId" || key === "view_id") {
-      serialized.view_id = String(value);
-      continue;
-    }
-
-    if (key === "includeRecordsSample" || key === "include_records_sample") {
-      serialized.include_records_sample = String(value);
-      continue;
-    }
-
-    if (key === "filter" && isRecord(value)) {
-      serialized.filter = serializeFilter(value);
-      continue;
-    }
-
-    if (Array.isArray(value)) {
-      serialized[key] = value.map(String);
-      continue;
-    }
-
-    serialized[key] = typeof value === "object" ? JSON.stringify(value) : String(value);
-  }
-
-  return serialized;
-}
-
-function serializeFilter(filter: Record<string, unknown>): string {
-  return Object.entries(filter)
-    .map(([field, condition]) => {
-      if (!isRecord(condition)) {
-        return `${field}[eq]:${String(condition)}`;
-      }
-
-      const clauses = Object.entries(condition).map(([operator, value]) => {
-        if (Array.isArray(value)) {
-          return `${field}[${operator}]:[${value.map(String).join(",")}]`;
-        }
-
-        return `${field}[${operator}]:${String(value)}`;
-      });
-
-      return clauses.join(";");
-    })
-    .join(";");
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function buildBulkParams(options: BulkMutationOptions): Record<string, string> {

--- a/packages/twenty-sdk/src/cli/utilities/search/services/__tests__/search.service.spec.ts
+++ b/packages/twenty-sdk/src/cli/utilities/search/services/__tests__/search.service.spec.ts
@@ -1,246 +1,39 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { SearchService } from "../search.service";
 
 describe("SearchService", () => {
   describe("search", () => {
-    it("searches with query", async () => {
+    it("delegates through the shared read backend when provided", async () => {
       const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [
-                  {
-                    cursor: "cursor-1",
-                    node: {
-                      recordId: "1",
-                      objectNameSingular: "person",
-                      objectLabelSingular: "Person",
-                      label: "John",
-                      imageUrl: null,
-                      tsRankCD: 0.9,
-                      tsRank: 0.8,
-                    },
-                  },
-                  {
-                    cursor: "cursor-2",
-                    node: {
-                      recordId: "2",
-                      objectNameSingular: "company",
-                      objectLabelSingular: "Company",
-                      label: "Acme",
-                      imageUrl: null,
-                      tsRankCD: 0.7,
-                      tsRank: 0.6,
-                    },
-                  },
-                ],
-              },
-            },
-          },
+        post: vi.fn(),
+      };
+      const mockReadBackend = {
+        runSearch: vi.fn().mockResolvedValue({
+          data: [{ recordId: "1", label: "John" }],
+          pageInfo: { hasNextPage: false },
         }),
       };
 
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test" });
-
-      expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
-        query: expect.stringContaining("query Search"),
-        variables: {
-          searchInput: "test",
-          limit: 20,
-          after: undefined,
-          filter: undefined,
-          includedObjectNameSingulars: undefined,
-          excludedObjectNameSingulars: undefined,
-        },
-      });
-      expect(result.data).toHaveLength(2);
-      expect(result.data[0].recordId).toBe("1");
-      expect(result.data[0].objectNameSingular).toBe("person");
-      expect(result.data[0].cursor).toBe("cursor-1");
-      expect(result.data[1].recordId).toBe("2");
-    });
-
-    it("searches with limit", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [
-                  {
-                    cursor: "cursor-1",
-                    node: {
-                      recordId: "1",
-                      objectNameSingular: "person",
-                      objectLabelSingular: "Person",
-                      label: "John",
-                      imageUrl: null,
-                      tsRankCD: 0.9,
-                      tsRank: 0.8,
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test", limit: 5 });
-
-      expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
-        query: expect.stringContaining("query Search"),
-        variables: {
-          searchInput: "test",
-          limit: 5,
-          after: undefined,
-          filter: undefined,
-          includedObjectNameSingulars: undefined,
-          excludedObjectNameSingulars: undefined,
-        },
-      });
-      expect(result.data).toHaveLength(1);
-    });
-
-    it("searches with objects filter", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [
-                  {
-                    cursor: "cursor-1",
-                    node: {
-                      recordId: "1",
-                      objectNameSingular: "person",
-                      objectLabelSingular: "Person",
-                      label: "John",
-                      imageUrl: null,
-                      tsRankCD: 0.9,
-                      tsRank: 0.8,
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test", objects: ["person", "company"] });
-
-      expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
-        query: expect.stringContaining("query Search"),
-        variables: {
-          searchInput: "test",
-          limit: 20,
-          after: undefined,
-          filter: undefined,
-          includedObjectNameSingulars: ["person", "company"],
-          excludedObjectNameSingulars: undefined,
-        },
-      });
-      expect(result.data).toHaveLength(1);
-    });
-
-    it("searches with exclude filter", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [
-                  {
-                    cursor: "cursor-1",
-                    node: {
-                      recordId: "1",
-                      objectNameSingular: "task",
-                      objectLabelSingular: "Task",
-                      label: "Task 1",
-                      imageUrl: null,
-                      tsRankCD: 0.9,
-                      tsRank: 0.8,
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test", excludeObjects: ["person", "company"] });
-
-      expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
-        query: expect.stringContaining("query Search"),
-        variables: {
-          searchInput: "test",
-          limit: 20,
-          after: undefined,
-          filter: undefined,
-          includedObjectNameSingulars: undefined,
-          excludedObjectNameSingulars: ["person", "company"],
-        },
-      });
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].objectNameSingular).toBe("task");
-    });
-
-    it("searches with all options combined", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [
-                  {
-                    cursor: "cursor-1",
-                    node: {
-                      recordId: "1",
-                      objectNameSingular: "person",
-                      objectLabelSingular: "Person",
-                      label: "John",
-                      imageUrl: null,
-                      tsRankCD: 0.9,
-                      tsRank: 0.8,
-                    },
-                  },
-                ],
-              },
-            },
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({
+      const service = new SearchService(mockApi as never, mockReadBackend as never);
+      const options = {
         query: "john",
-        limit: 10,
+        limit: 5,
         objects: ["person"],
         excludeObjects: ["note"],
-      });
+        after: "cursor-1",
+        filter: { city: { eq: "NYC" } },
+      };
+      const result = await service.search(options);
 
-      expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
-        query: expect.stringContaining("query Search"),
-        variables: {
-          searchInput: "john",
-          limit: 10,
-          after: undefined,
-          filter: undefined,
-          includedObjectNameSingulars: ["person"],
-          excludedObjectNameSingulars: ["note"],
-        },
+      expect(mockReadBackend.runSearch).toHaveBeenCalledWith(options);
+      expect(mockApi.post).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        data: [{ recordId: "1", label: "John" }],
+        pageInfo: { hasNextPage: false },
       });
-      expect(result.data).toHaveLength(1);
     });
 
-    it("searches with after cursor and filter", async () => {
+    it("uses the API implementation when no shared read backend is provided", async () => {
       const mockApi = {
         post: vi.fn().mockResolvedValue({
           data: {
@@ -248,95 +41,21 @@ describe("SearchService", () => {
               search: {
                 edges: [
                   {
-                    cursor: "cursor-2",
+                    cursor: "cursor-1",
                     node: {
-                      recordId: "2",
+                      recordId: "1",
                       objectNameSingular: "person",
                       objectLabelSingular: "Person",
-                      label: "Jane",
+                      label: "John",
                       imageUrl: null,
-                      tsRankCD: 0.8,
-                      tsRank: 0.7,
+                      tsRankCD: 0.9,
+                      tsRank: 0.8,
                     },
                   },
                 ],
-              },
-            },
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({
-        query: "jane",
-        after: "cursor-1",
-        filter: {
-          id: { eq: "rec-2" },
-        },
-      });
-
-      expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
-        query: expect.stringContaining("query Search"),
-        variables: {
-          searchInput: "jane",
-          limit: 20,
-          after: "cursor-1",
-          filter: {
-            id: { eq: "rec-2" },
-          },
-          includedObjectNameSingulars: undefined,
-          excludedObjectNameSingulars: undefined,
-        },
-      });
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].cursor).toBe("cursor-2");
-    });
-
-    it("returns empty data when no results", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: { data: { search: { edges: [] } } },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "nonexistent" });
-
-      expect(result).toEqual({ data: [], pageInfo: undefined });
-    });
-
-    it("handles missing data gracefully", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({ data: {} }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test" });
-
-      expect(result).toEqual({ data: [], pageInfo: undefined });
-    });
-
-    it("handles missing search field gracefully", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({ data: { data: {} } }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test" });
-
-      expect(result).toEqual({ data: [], pageInfo: undefined });
-    });
-
-    it("returns pageInfo when available", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [],
                 pageInfo: {
-                  hasNextPage: true,
-                  endCursor: "cursor-2",
+                  hasNextPage: false,
+                  endCursor: "cursor-1",
                 },
               },
             },
@@ -344,97 +63,37 @@ describe("SearchService", () => {
         }),
       };
 
-      const service = new SearchService(mockApi as any);
-      const result = await service.search({ query: "test" });
-
-      expect(result.pageInfo).toEqual({
-        hasNextPage: true,
-        endCursor: "cursor-2",
-      });
-    });
-
-    it("propagates API errors", async () => {
-      const mockApi = {
-        post: vi.fn().mockRejectedValue(new Error("Network error")),
-      };
-
-      const service = new SearchService(mockApi as any);
-
-      await expect(service.search({ query: "test" })).rejects.toThrow("Network error");
-    });
-
-    it("propagates GraphQL errors", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            errors: [
-              {
-                message: 'Variable "$limit" of type "Int" used in position expecting type "Int!".',
-              },
-            ],
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-
-      await expect(service.search({ query: "test" })).rejects.toThrow(
-        'Variable "$limit" of type "Int" used in position expecting type "Int!".',
-      );
-    });
-
-    it("sends correct GraphQL query structure", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: { data: { search: [] } },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      await service.search({ query: "test" });
-
-      const call = mockApi.post.mock.calls[0];
-      const query = call[1].query;
-
-      expect(query).toContain("query Search");
-      expect(query).toContain("$searchInput: String!");
-      expect(query).toContain("$limit: Int!");
-      expect(query).toContain("$after: String");
-      expect(query).toContain("$filter: ObjectRecordFilterInput");
-      expect(query).toContain("$includedObjectNameSingulars: [String!]");
-      expect(query).toContain("$excludedObjectNameSingulars: [String!]");
-      expect(query).toContain("after: $after");
-      expect(query).toContain("filter: $filter");
-      expect(query).toContain("edges");
-      expect(query).toContain("cursor");
-      expect(query).toContain("recordId");
-      expect(query).toContain("objectNameSingular");
-      expect(query).toContain("objectLabelSingular");
-      expect(query).toContain("label");
-    });
-
-    it("defaults limit to 20 when omitted", async () => {
-      const mockApi = {
-        post: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              search: {
-                edges: [],
-              },
-            },
-          },
-        }),
-      };
-
-      const service = new SearchService(mockApi as any);
-      await service.search({ query: "test" });
+      const service = new SearchService(mockApi as never);
+      const result = await service.search({ query: "john" });
 
       expect(mockApi.post).toHaveBeenCalledWith("/graphql", {
         query: expect.stringContaining("query Search"),
-        variables: expect.objectContaining({
-          searchInput: "test",
+        variables: {
+          searchInput: "john",
           limit: 20,
-        }),
+          after: undefined,
+          filter: undefined,
+          includedObjectNameSingulars: undefined,
+          excludedObjectNameSingulars: undefined,
+        },
+      });
+      expect(result).toEqual({
+        data: [
+          {
+            recordId: "1",
+            objectNameSingular: "person",
+            objectLabelSingular: "Person",
+            label: "John",
+            imageUrl: null,
+            tsRankCD: 0.9,
+            tsRank: 0.8,
+            cursor: "cursor-1",
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          endCursor: "cursor-1",
+        },
       });
     });
   });

--- a/packages/twenty-sdk/src/cli/utilities/search/services/api-search.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/search/services/api-search.service.ts
@@ -1,0 +1,110 @@
+import { ApiService } from "../../api/services/api.service";
+import { GraphQLResponse, formatGraphqlErrors } from "../../api/graphql-response";
+import { CliError } from "../../errors/cli-error";
+
+type SearchApiClient = Pick<ApiService, "post">;
+
+const DEFAULT_SEARCH_LIMIT = 20;
+
+export interface SearchResult {
+  recordId: string;
+  objectNameSingular: string;
+  objectLabelSingular: string;
+  label: string;
+  imageUrl?: string | null;
+  tsRankCD: number;
+  tsRank: number;
+  cursor?: string;
+}
+
+export interface SearchPageInfo {
+  hasNextPage?: boolean;
+  endCursor?: string;
+}
+
+export interface SearchResponse {
+  data: SearchResult[];
+  pageInfo?: SearchPageInfo;
+}
+
+export interface SearchOptions {
+  query: string;
+  limit?: number;
+  objects?: string[];
+  excludeObjects?: string[];
+  after?: string;
+  filter?: Record<string, unknown>;
+}
+
+type GraphQLSearchResponse = GraphQLResponse<{
+  search?: {
+    edges?: Array<{
+      cursor: string;
+      node: SearchResult;
+    }>;
+    pageInfo?: SearchPageInfo;
+  };
+}>;
+
+export class ApiSearchService {
+  constructor(private readonly api: SearchApiClient) {}
+
+  async search(options: SearchOptions): Promise<SearchResponse> {
+    const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
+    const query = `
+      query Search($searchInput: String!, $limit: Int!, $after: String, $filter: ObjectRecordFilterInput, $includedObjectNameSingulars: [String!], $excludedObjectNameSingulars: [String!]) {
+        search(
+          searchInput: $searchInput
+          limit: $limit
+          after: $after
+          filter: $filter
+          includedObjectNameSingulars: $includedObjectNameSingulars
+          excludedObjectNameSingulars: $excludedObjectNameSingulars
+        ) {
+          edges {
+            cursor
+            node {
+              recordId
+              objectNameSingular
+              objectLabelSingular
+              label
+              imageUrl
+              tsRankCD
+              tsRank
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    `;
+    const variables = {
+      searchInput: options.query,
+      limit,
+      after: options.after,
+      filter: options.filter,
+      includedObjectNameSingulars: options.objects,
+      excludedObjectNameSingulars: options.excludeObjects,
+    };
+    const response = await this.api.post<GraphQLSearchResponse>("/graphql", { query, variables });
+    const payload = response.data;
+    const errorMessage = formatGraphqlErrors(payload);
+
+    if (errorMessage) {
+      throw new CliError(errorMessage, "API_ERROR");
+    }
+
+    const search = payload.data?.search;
+
+    return {
+      data:
+        search?.edges?.map((edge) => ({
+          ...edge.node,
+          cursor: edge.cursor,
+        })) ?? [],
+      pageInfo: search?.pageInfo,
+    };
+  }
+}

--- a/packages/twenty-sdk/src/cli/utilities/search/services/search.service.ts
+++ b/packages/twenty-sdk/src/cli/utilities/search/services/search.service.ts
@@ -1,108 +1,32 @@
 import { ApiService } from "../../api/services/api.service";
-import { GraphQLResponse, formatGraphqlErrors } from "../../api/graphql-response";
-import { CliError } from "../../errors/cli-error";
+import type { SearchReadBackend } from "../../readbackend/types";
+import { ApiSearchService, type SearchOptions } from "./api-search.service";
 
 type SearchApiClient = Pick<ApiService, "post">;
 
-const DEFAULT_SEARCH_LIMIT = 20;
-
-export interface SearchResult {
-  recordId: string;
-  objectNameSingular: string;
-  objectLabelSingular: string;
-  label: string;
-  imageUrl?: string | null;
-  tsRankCD: number;
-  tsRank: number;
-  cursor?: string;
-}
-
-export interface SearchPageInfo {
-  hasNextPage?: boolean;
-  endCursor?: string;
-}
-
-export interface SearchResponse {
-  data: SearchResult[];
-  pageInfo?: SearchPageInfo;
-}
-
-type GraphQLSearchResponse = GraphQLResponse<{
-  search?: {
-    edges?: Array<{
-      cursor: string;
-      node: SearchResult;
-    }>;
-    pageInfo?: SearchPageInfo;
-  };
-}>;
+export type {
+  SearchOptions,
+  SearchPageInfo,
+  SearchResponse,
+  SearchResult,
+} from "./api-search.service";
 
 export class SearchService {
-  constructor(private api: SearchApiClient) {}
+  private readonly readBackend: SearchReadBackend;
 
-  async search(options: {
-    query: string;
-    limit?: number;
-    objects?: string[];
-    excludeObjects?: string[];
-    after?: string;
-    filter?: Record<string, unknown>;
-  }): Promise<SearchResponse> {
-    const limit = options.limit ?? DEFAULT_SEARCH_LIMIT;
-    const query = `
-      query Search($searchInput: String!, $limit: Int!, $after: String, $filter: ObjectRecordFilterInput, $includedObjectNameSingulars: [String!], $excludedObjectNameSingulars: [String!]) {
-        search(
-          searchInput: $searchInput
-          limit: $limit
-          after: $after
-          filter: $filter
-          includedObjectNameSingulars: $includedObjectNameSingulars
-          excludedObjectNameSingulars: $excludedObjectNameSingulars
-        ) {
-          edges {
-            cursor
-            node {
-              recordId
-              objectNameSingular
-              objectLabelSingular
-              label
-              imageUrl
-              tsRankCD
-              tsRank
-            }
-          }
-          pageInfo {
-            hasNextPage
-            endCursor
-          }
-        }
-      }
-    `;
-    const variables = {
-      searchInput: options.query,
-      limit,
-      after: options.after,
-      filter: options.filter,
-      includedObjectNameSingulars: options.objects,
-      excludedObjectNameSingulars: options.excludeObjects,
-    };
-    const response = await this.api.post<GraphQLSearchResponse>("/graphql", { query, variables });
-    const payload = response.data;
-    const errorMessage = formatGraphqlErrors(payload);
-
-    if (errorMessage) {
-      throw new CliError(errorMessage, "API_ERROR");
+  constructor(api: SearchApiClient, readBackend?: SearchReadBackend) {
+    if (readBackend) {
+      this.readBackend = readBackend;
+      return;
     }
 
-    const search = payload.data?.search;
-
-    return {
-      data:
-        search?.edges?.map((edge) => ({
-          ...edge.node,
-          cursor: edge.cursor,
-        })) ?? [],
-      pageInfo: search?.pageInfo,
+    const apiSearch = new ApiSearchService(api);
+    this.readBackend = {
+      runSearch: (options) => apiSearch.search(options),
     };
+  }
+
+  async search(options: SearchOptions) {
+    return this.readBackend.runSearch(options);
   }
 }

--- a/packages/twenty-sdk/src/cli/utilities/shared/services.ts
+++ b/packages/twenty-sdk/src/cli/utilities/shared/services.ts
@@ -10,10 +10,14 @@ import { ExportService } from "../file/services/export.service";
 import { ImportService } from "../file/services/import.service";
 import { McpService } from "../mcp/services/mcp.service";
 import { SearchService } from "../search/services/search.service";
+import { DbProfileService } from "../db/services/db-profile.service";
+import { DbStatusService } from "../db/services/db-status.service";
 import { GlobalOptions } from "./global-options";
 
 export interface CliServices {
   config: ConfigService;
+  dbProfiles: DbProfileService;
+  dbStatus: DbStatusService;
   api: ApiService;
   publicHttp: PublicHttpService;
   search: SearchService;
@@ -33,6 +37,8 @@ export function createOutputService(globalOptions: GlobalOptions): OutputService
 
 export function createServices(globalOptions: GlobalOptions): CliServices {
   const config = new ConfigService();
+  const dbProfiles = new DbProfileService(config);
+  const dbStatus = new DbStatusService(dbProfiles);
   const api = new ApiService(config, {
     workspace: globalOptions.workspace,
     debug: globalOptions.debug,
@@ -56,6 +62,8 @@ export function createServices(globalOptions: GlobalOptions): CliServices {
 
   return {
     config,
+    dbProfiles,
+    dbStatus,
     api,
     publicHttp,
     search,

--- a/packages/twenty-sdk/src/cli/utilities/shared/services.ts
+++ b/packages/twenty-sdk/src/cli/utilities/shared/services.ts
@@ -10,8 +10,14 @@ import { ExportService } from "../file/services/export.service";
 import { ImportService } from "../file/services/import.service";
 import { McpService } from "../mcp/services/mcp.service";
 import { SearchService } from "../search/services/search.service";
+import { ApiSearchService } from "../search/services/api-search.service";
+import { DbConfigResolverService } from "../db/services/db-config-resolver.service";
+import { DbRecordsReadService } from "../db/services/db-records-read.service";
+import { DbSearchService } from "../db/services/db-search.service";
 import { DbProfileService } from "../db/services/db-profile.service";
 import { DbStatusService } from "../db/services/db-status.service";
+import { ReadBackendService } from "../readbackend/read-backend.service";
+import { ApiRecordsReadService } from "../records/services/api-records-read.service";
 import { GlobalOptions } from "./global-options";
 
 export interface CliServices {
@@ -38,7 +44,8 @@ export function createOutputService(globalOptions: GlobalOptions): OutputService
 export function createServices(globalOptions: GlobalOptions): CliServices {
   const config = new ConfigService();
   const dbProfiles = new DbProfileService(config);
-  const dbStatus = new DbStatusService(dbProfiles);
+  const dbConfigResolver = new DbConfigResolverService(dbProfiles);
+  const dbStatus = new DbStatusService(dbConfigResolver);
   const api = new ApiService(config, {
     workspace: globalOptions.workspace,
     debug: globalOptions.debug,
@@ -49,13 +56,25 @@ export function createServices(globalOptions: GlobalOptions): CliServices {
     debug: globalOptions.debug,
     noRetry: globalOptions.noRetry,
   });
-  const search = new SearchService(api);
+  const metadata = new MetadataService(api);
+  const apiSearch = new ApiSearchService(api);
+  const apiRecordsRead = new ApiRecordsReadService(api);
+  const readBackend = new ReadBackendService(
+    dbConfigResolver,
+    apiSearch,
+    apiRecordsRead,
+    {
+      search: new DbSearchService(metadata),
+      records: new DbRecordsReadService(metadata),
+    },
+    { workspace: globalOptions.workspace },
+  );
+  const search = new SearchService(api, readBackend);
   const mcp = new McpService(api, config, {
     workspace: globalOptions.workspace,
     debug: globalOptions.debug,
   });
-  const records = new RecordsService(api);
-  const metadata = new MetadataService(api);
+  const records = new RecordsService(api, { readBackend });
   const output = createOutputService(globalOptions);
   const importer = new ImportService();
   const exporter = new ExportService();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       papaparse:
         specifier: ^5.4.1
         version: 5.5.3
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -60,6 +63,9 @@ importers:
       '@types/papaparse':
         specifier: ^5.3.14
         version: 5.5.2
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -652,6 +658,9 @@ packages:
   '@types/papaparse@5.5.2':
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
@@ -1229,6 +1238,40 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1243,6 +1286,22 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -1321,6 +1380,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1527,6 +1590,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -1924,6 +1991,12 @@ snapshots:
   '@types/papaparse@5.5.2':
     dependencies:
       '@types/node': 25.5.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.5.2
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -2513,6 +2586,41 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
@@ -2524,6 +2632,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prebuild-install@7.1.3:
     dependencies:
@@ -2630,6 +2748,8 @@ snapshots:
       simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -2835,6 +2955,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- add direct DB-backed read routing for supported lookup paths via `TWENTY_DATABASE_URL` and active DB profiles
- keep write and mutation flows on the official API while adding DB-backed search and records read services
- update DB/help documentation and add coverage for config resolution, routing, search, and records reads

## Test Plan
- [x] `pnpm --filter ./packages/twenty-sdk test`
- [x] `pnpm --filter ./packages/twenty-sdk typecheck`
- [x] `pnpm --filter ./packages/twenty-sdk build`
- [x] `pnpm prek:run`
- [x] `pnpm check:repo-hygiene`